### PR TITLE
Hybrid sorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,19 @@ int main()
 ```
 
 **cpp-sort** library also provides *sorters* as well as *sorter adapters*
-which can be used by `cppsort::sort` to sort a collection. Everything lives
-in the `cppsort` namespace. You can read more about the available sorting
-tools in the documentation:
+which can be used by `cppsort::sort` to sort a collection. It is possible
+to information about the sorters and sorter adapters with *sorter traits*.
+Everything lives in the `cppsort` namespace. You can read more about the
+available sorting tools in the documentation:
 
 * [`cppsort::sort`](doc/sort.md)
 * [Sorters](doc/sorters.md)
 * [Sorter adapters](doc/sorter-adapters.md)
+* [Sorter traits](doc/sorter-traits.md)
 
 There are also a few other utilities used by the library and made available
-to the users, even though they're not sorting-related. You can read about them
-in the following page:
+to the users, even though they are not sorting-related. You can read about
+them in the following page:
 
 * [Miscellaneous utilities](doc/utilities.md)
 

--- a/doc/sorter-adapters.md
+++ b/doc/sorter-adapters.md
@@ -31,6 +31,33 @@ template<
 struct counting_sorter;
 ```
 
+`hybrid_sorter`
+---------------
+
+```cpp
+#include <cpp-sort/sorters/hybrid_sorter.h>
+```
+
+The goal of this sorter adapter is to aggregate several sorters into one unique
+sorter. The new sorter will call the appropriate sorting algorithm based on the
+iterator category of the iterable to sort. Therefore, the different sorters passed
+to it should have different iterator categories so that the call to `operator()`
+is not ambiguous. For example, the following sorter will call a pattern-defeating
+quicksort to sort a random-access iterable, an insertion sort to sort a bidirectional
+iterable and a bubble sort to sort a forward iterable:
+
+```cpp
+using general_purpose_sort = hybrid_sorter<
+    bubble_sorter,
+    insertion_sorter,
+    pdq_sorter
+>;
+```
+
+The order of the parameters does not matter. The only thing that matters is that
+the different sorter shall have a different `cppsort::iterator_category` so that
+they can work side by side without overlapping.
+
 `self_sorter`
 -------------
 

--- a/doc/sorter-traits.md
+++ b/doc/sorter-traits.md
@@ -1,0 +1,54 @@
+Sorter traits
+=============
+
+```cpp
+#include <cpp-sort/sorter_traits.h>
+```
+
+The class template `sorter_traits<Sorter>` contains information about
+sorters and sorter adapters such as the kind of iterators accepted by
+a sorter or whether it implements or not a stable sorting algorithm.
+
+`sorter_traits`
+---------------
+
+Here is the basic definition of `sorter_traits`:
+
+```cpp
+template<typename Sorter>
+struct sorter_traits {};
+```
+
+This class can be specialized for every sorter object and contains the
+following fields:
+
+* `using iterator_category = /* depends on the sorter */;`
+* `static constexpr bool is_stable = /* depends on the context */;`
+
+The non-specialized version of `sorter_traits` is defined but empty for
+SFINAE friendliness.
+
+`iterator_category`
+-------------------
+
+```cpp
+template<typename Sorter>
+using iterator_category = typename sorter_traits<Sorter>::iterator_category;
+```
+
+Some tools needs to know which category of iterators a sorting algorithm
+can work with. Therefore, a well-defined sorter provides one of the standard
+library [iterator tags](http://en.cppreference.com/w/cpp/iterator/iterator_tags)
+in order to document that.
+
+`is_stable`
+-----------
+
+```cpp
+template<typename Sorter>
+constexpr bool is_stable = sorter_traits<Sorter>::is_stable;
+```
+
+This variable template contains a boolean value which tells whether a sorting
+algorithm is [stable](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+or not. This information may be useful in some contexts.

--- a/doc/sorters.md
+++ b/doc/sorters.md
@@ -51,7 +51,10 @@ implementation defines it as follows:
 ```cpp
 using default_sorter = self_sorter<
     small_array_sorter<
-        pdq_sorter,
+        hybrid_sorter<
+            insertion_sorter,
+            pdq_sorter
+        >,
         std::make_index_sequence<10u>
     >
 >;
@@ -66,8 +69,8 @@ using default_sorter = self_sorter<
 
 Implements an [insertion sort](https://en.wikipedia.org/wiki/Insertion_sort).
 
-    Best        Average     Worst       Memory      Stable
-    n           n²          n²          1           Yes
+    Best        Average     Worst       Memory      Stable      Iterators
+    n           n²          n²          1           Yes         Bidirectional
 
 `merge_sorter`
 --------------
@@ -78,8 +81,8 @@ Implements an [insertion sort](https://en.wikipedia.org/wiki/Insertion_sort).
 
 Implements a [merge sort](https://en.wikipedia.org/wiki/Merge_sort).
 
-    Best        Average     Worst       Memory      Stable
-    n log n     n log n     n log n     n           Yes
+    Best        Average     Worst       Memory      Stable      Iterators
+    n log n     n log n     n log n     n           Yes         Random access
 
 `pdq_sorter`
 ------------
@@ -91,8 +94,8 @@ Implements a [merge sort](https://en.wikipedia.org/wiki/Merge_sort).
 Implements a [pattern-defeating quicksort](https://github.com/orlp/pdqsort).
 
 
-    Best        Average     Worst       Memory      Stable
-    n           n log n     n log n     log n       No
+    Best        Average     Worst       Memory      Stable      Iterators
+    n           n log n     n log n     log n       No          Random access
 
 `std_sorter`
 ------------
@@ -104,8 +107,8 @@ Implements a [pattern-defeating quicksort](https://github.com/orlp/pdqsort).
 Uses the standard library [`std::sort`](http://en.cppreference.com/w/cpp/algorithm/sort)
 to sort a collection.
 
-    Best        Average     Worst       Memory      Stable
-    ?           n log n     n log n     ?           No
+    Best        Average     Worst       Memory      Stable      Iterators
+    ?           n log n     n log n     ?           No          Random access
 
 `tim_sorter`
 ------------
@@ -116,5 +119,5 @@ to sort a collection.
 
 Implements a [timsort](https://en.wikipedia.org/wiki/Timsort) algorithm.
 
-    Best        Average     Worst       Memory      Stable
-    n           n log n     n log n     n           Yes
+    Best        Average     Worst       Memory      Stable      Iterators
+    n           n log n     n log n     n           Yes         Random access

--- a/include/cpp-sort/sorter_traits.h
+++ b/include/cpp-sort/sorter_traits.h
@@ -21,46 +21,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef CPPSORT_SORTERS_PDQ_SORTER_H_
-#define CPPSORT_SORTERS_PDQ_SORTER_H_
-
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
-#include <functional>
-#include <iterator>
-#include <cpp-sort/sorter_traits.h>
-#include "../detail/pdqsort.h"
+#ifndef CPPSORT_SORTER_TRAITS_H_
+#define CPPSORT_SORTER_TRAITS_H_
 
 namespace cppsort
 {
-    ////////////////////////////////////////////////////////////
-    // Sorter
-
-    struct pdq_sorter
+    template<typename Sorter>
+    struct sorter_traits
     {
-        template<
-            typename RandomAccessIterable,
-            typename Compare = std::less<>
-        >
-        auto operator()(RandomAccessIterable& iterable,
-                        Compare compare={},
-                        std::random_access_iterator_tag={}) const
-            -> void
-        {
-            detail::pdqsort(std::begin(iterable), std::end(iterable), compare);
-        }
+        // Defined but empty for SFINAE friendliness
     };
 
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
+    template<typename Sorter>
+    using iterator_category = typename sorter_traits<Sorter>::iterator_category;
 
-    template<>
-    struct sorter_traits<pdq_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        static constexpr bool is_stable = false;
-    };
+    template<typename Sorter>
+    constexpr bool is_stable = sorter_traits<Sorter>::is_stable;
 }
 
-#endif // CPPSORT_SORTERS_PDQ_SORTER_H_
+#endif // CPPSORT_SORTER_TRAITS_H_

--- a/include/cpp-sort/sorters/counting_sorter.h
+++ b/include/cpp-sort/sorters/counting_sorter.h
@@ -29,10 +29,14 @@
 ////////////////////////////////////////////////////////////
 #include <cstddef>
 #include <functional>
+#include <cpp-sort/sorter_traits.h>
 #include "../detail/comparison_counter.h"
 
 namespace cppsort
 {
+    ////////////////////////////////////////////////////////////
+    // Sorter
+
     template<
         typename Sorter,
         typename CountType = std::size_t
@@ -50,6 +54,16 @@ namespace cppsort
             Sorter{}(iterable, cmp);
             return cmp.count;
         }
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Sorter traits
+
+    template<typename Sorter, typename CountType>
+    struct sorter_traits<counting_sorter<Sorter, CountType>>
+    {
+        using iterator_category = iterator_category<Sorter>;
+        static constexpr bool is_stable = is_stable<Sorter>;
     };
 }
 

--- a/include/cpp-sort/sorters/default_sorter.h
+++ b/include/cpp-sort/sorters/default_sorter.h
@@ -28,6 +28,8 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <utility>
+#include <cpp-sort/sorters/hybrid_sorter.h>
+#include <cpp-sort/sorters/insertion_sorter.h>
 #include <cpp-sort/sorters/pdq_sorter.h>
 #include <cpp-sort/sorters/self_sorter.h>
 #include <cpp-sort/sorters/small_array_sorter.h>
@@ -36,7 +38,10 @@ namespace cppsort
 {
     using default_sorter = self_sorter<
         small_array_sorter<
-            pdq_sorter,
+            hybrid_sorter<
+                insertion_sorter,
+                pdq_sorter
+            >,
             std::make_index_sequence<10u>
         >
     >;

--- a/include/cpp-sort/sorters/hybrid_sorter.h
+++ b/include/cpp-sort/sorters/hybrid_sorter.h
@@ -29,9 +29,14 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <type_traits>
+#include <cpp-sort/sorter_traits.h>
 
 namespace cppsort
 {
+    ////////////////////////////////////////////////////////////
+    // Sorter
+
     template<typename... Sorters>
     class hybrid_sorter
     {
@@ -66,6 +71,16 @@ namespace cppsort
                 using category = typename std::iterator_traits<decltype(std::begin(iterable))>::iterator_category;
                 sorters(iterable, compare, category{});
             }
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Sorter traits
+
+    template<typename... Sorters>
+    struct sorter_traits<hybrid_sorter<Sorters...>>
+    {
+        using iterator_category = std::common_type_t<iterator_category<Sorters>...>;
+        static constexpr bool is_stable = false;
     };
 }
 

--- a/include/cpp-sort/sorters/hybrid_sorter.h
+++ b/include/cpp-sort/sorters/hybrid_sorter.h
@@ -21,21 +21,52 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef CPPSORT_SORTERS_H_
-#define CPPSORT_SORTERS_H_
+#ifndef CPPSORT_SORTERS_HYBRID_SORTER_H_
+#define CPPSORT_SORTERS_HYBRID_SORTER_H_
 
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <cpp-sort/sorters/counting_sorter.h>
-#include <cpp-sort/sorters/default_sorter.h>
-#include <cpp-sort/sorters/hybrid_sorter.h>
-#include <cpp-sort/sorters/insertion_sorter.h>
-#include <cpp-sort/sorters/merge_sorter.h>
-#include <cpp-sort/sorters/pdq_sorter.h>
-#include <cpp-sort/sorters/self_sorter.h>
-#include <cpp-sort/sorters/small_array_sorter.h>
-#include <cpp-sort/sorters/std_sorter.h>
-#include <cpp-sort/sorters/tim_sorter.h>
+#include <functional>
+#include <iterator>
 
-#endif // CPPSORT_SORTERS_H_
+namespace cppsort
+{
+    template<typename... Sorters>
+    class hybrid_sorter
+    {
+        private:
+
+            template<typename Head, typename... Tail>
+            struct merge_sorters:
+                Head, merge_sorters<Tail...>
+            {
+                using Head::operator();
+                using merge_sorters<Tail...>::operator();
+            };
+
+            template<typename Head>
+            struct merge_sorters<Head>:
+                Head
+            {
+                using Head::operator();
+            };
+
+            merge_sorters<Sorters...> sorters;
+
+        public:
+
+            template<
+                typename Iterable,
+                typename Compare = std::less<>
+            >
+            auto operator()(Iterable& iterable, Compare compare={}) const
+                -> void
+            {
+                using category = typename std::iterator_traits<decltype(std::begin(iterable))>::iterator_category;
+                sorters(iterable, compare, category{});
+            }
+    };
+}
+
+#endif // CPPSORT_SORTERS_HYBRID_SORTER_H_

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -29,10 +29,14 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_traits.h>
 #include "../detail/insertion_sort.h"
 
 namespace cppsort
 {
+    ////////////////////////////////////////////////////////////
+    // Sorter
+
     struct insertion_sorter
     {
         template<
@@ -46,6 +50,16 @@ namespace cppsort
         {
             detail::insertion_sort(std::begin(iterable), std::end(iterable), compare);
         }
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Sorter traits
+
+    template<>
+    struct sorter_traits<insertion_sorter>
+    {
+        using iterator_category = std::bidirectional_iterator_tag;
+        static constexpr bool is_stable = true;
     };
 }
 

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -43,9 +43,7 @@ namespace cppsort
             typename BidirectionalIterable,
             typename Compare = std::less<>
         >
-        auto operator()(BidirectionalIterable& iterable,
-                        Compare compare={},
-                        std::bidirectional_iterator_tag={}) const
+        auto operator()(BidirectionalIterable& iterable, Compare compare={}) const
             -> void
         {
             detail::insertion_sort(std::begin(iterable), std::end(iterable), compare);

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -39,7 +39,9 @@ namespace cppsort
             typename BidirectionalIterable,
             typename Compare = std::less<>
         >
-        auto operator()(BidirectionalIterable& iterable, Compare compare={}) const
+        auto operator()(BidirectionalIterable& iterable,
+                        Compare compare={},
+                        std::bidirectional_iterator_tag={}) const
             -> void
         {
             detail::insertion_sort(std::begin(iterable), std::end(iterable), compare);

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -39,7 +39,9 @@ namespace cppsort
             typename RandomAccessIterable,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+        auto operator()(RandomAccessIterable& iterable,
+                        Compare compare={},
+                        std::random_access_iterator_tag={}) const
             -> void
         {
             detail::merge_sort(std::begin(iterable), std::end(iterable), compare);

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -29,10 +29,14 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_traits.h>
 #include "../detail/merge_sort.h"
 
 namespace cppsort
 {
+    ////////////////////////////////////////////////////////////
+    // Sorter
+
     struct merge_sorter
     {
         template<
@@ -46,6 +50,16 @@ namespace cppsort
         {
             detail::merge_sort(std::begin(iterable), std::end(iterable), compare);
         }
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Sorter traits
+
+    template<>
+    struct sorter_traits<merge_sorter>
+    {
+        using iterator_category = std::random_access_iterator_tag;
+        static constexpr bool is_stable = true;
     };
 }
 

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -43,9 +43,7 @@ namespace cppsort
             typename RandomAccessIterable,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable,
-                        Compare compare={},
-                        std::random_access_iterator_tag={}) const
+        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
             -> void
         {
             detail::merge_sort(std::begin(iterable), std::end(iterable), compare);

--- a/include/cpp-sort/sorters/pdq_sorter.h
+++ b/include/cpp-sort/sorters/pdq_sorter.h
@@ -43,9 +43,7 @@ namespace cppsort
             typename RandomAccessIterable,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable,
-                        Compare compare={},
-                        std::random_access_iterator_tag={}) const
+        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
             -> void
         {
             detail::pdqsort(std::begin(iterable), std::end(iterable), compare);

--- a/include/cpp-sort/sorters/pdq_sorter.h
+++ b/include/cpp-sort/sorters/pdq_sorter.h
@@ -39,7 +39,9 @@ namespace cppsort
             typename RandomAccessIterable,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+        auto operator()(RandomAccessIterable& iterable,
+                        Compare compare={},
+                        std::random_access_iterator_tag={}) const
             -> void
         {
             detail::pdqsort(std::begin(iterable), std::end(iterable), compare);

--- a/include/cpp-sort/sorters/small_array_sorter.h
+++ b/include/cpp-sort/sorters/small_array_sorter.h
@@ -32,11 +32,15 @@
 #include <functional>
 #include <type_traits>
 #include <utility>
+#include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/is_in_pack.h>
 #include "../detail/sort_n.h"
 
 namespace cppsort
 {
+    ////////////////////////////////////////////////////////////
+    // Sorter
+
     template<typename...>
     struct small_array_sorter;
 
@@ -85,6 +89,16 @@ namespace cppsort
     struct small_array_sorter<Sorter>:
         small_array_sorter<Sorter, std::make_index_sequence<33u>>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sorter traits
+
+    template<typename Sorter, std::size_t... Indices>
+    struct sorter_traits<small_array_sorter<Sorter, std::index_sequence<Indices...>>>
+    {
+        using iterator_category = iterator_category<Sorter>;
+        static constexpr bool is_stable = false;
+    };
 }
 
 #endif // CPPSORT_SORTERS_SMALL_ARRAY_SORTER_H_

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -30,9 +30,13 @@
 #include <algorithm>
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_traits.h>
 
 namespace cppsort
 {
+    ////////////////////////////////////////////////////////////
+    // Sorter
+
     struct std_sorter
     {
         template<
@@ -46,6 +50,16 @@ namespace cppsort
         {
             std::sort(std::begin(iterable), std::end(iterable), compare);
         }
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Sorter traits
+
+    template<>
+    struct sorter_traits<std_sorter>
+    {
+        using iterator_category = std::random_access_iterator_tag;
+        static constexpr bool is_stable = false;
     };
 }
 

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -43,9 +43,7 @@ namespace cppsort
             typename RandomAccessIterable,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable,
-                        Compare compare={},
-                        std::random_access_iterator_tag={}) const
+        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
             -> void
         {
             std::sort(std::begin(iterable), std::end(iterable), compare);

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -39,7 +39,9 @@ namespace cppsort
             typename RandomAccessIterable,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+        auto operator()(RandomAccessIterable& iterable,
+                        Compare compare={},
+                        std::random_access_iterator_tag={}) const
             -> void
         {
             std::sort(std::begin(iterable), std::end(iterable), compare);

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -29,10 +29,14 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_traits.h>
 #include "../detail/timsort.h"
 
 namespace cppsort
 {
+    ////////////////////////////////////////////////////////////
+    // Sorter
+
     struct tim_sorter
     {
         template<
@@ -46,6 +50,16 @@ namespace cppsort
         {
             detail::timsort(std::begin(iterable), std::end(iterable), compare);
         }
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Sorter traits
+
+    template<>
+    struct sorter_traits<tim_sorter>
+    {
+        using iterator_category = std::random_access_iterator_tag;
+        static constexpr bool is_stable = true;
     };
 }
 

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -43,9 +43,7 @@ namespace cppsort
             typename RandomAccessIterable,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable,
-                        Compare compare={},
-                        std::random_access_iterator_tag={}) const
+        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
             -> void
         {
             detail::timsort(std::begin(iterable), std::end(iterable), compare);

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -39,7 +39,9 @@ namespace cppsort
             typename RandomAccessIterable,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+        auto operator()(RandomAccessIterable& iterable,
+                        Compare compare={},
+                        std::random_access_iterator_tag={}) const
             -> void
         {
             detail::timsort(std::begin(iterable), std::end(iterable), compare);


### PR DESCRIPTION
Add `sorter_traits` which give information about a sorter's stability and the kind of iterators it works with. Use the latter property to implement `hybrid_sorter`, a sorter which can combine several sorters into one provided they work with different kinds of iterators.