### PR TITLE
Function pointers conversions for sorters

### DIFF
--- a/benchmarks/bars.py
+++ b/benchmarks/bars.py
@@ -1,0 +1,94 @@
+import math
+import os
+
+import numpy
+from matplotlib import pyplot as plt
+
+
+
+distribution_names = {
+    "shuffled_16_values_int": "Shuffled (16 values)",
+    "shuffled_int": "Shuffled",
+    "all_equal_int": "All equal",
+    "ascending_int": "Ascending",
+    "descending_int": "Descending",
+    "pipe_organ_int": "Pipe organ",
+    "push_front_int": "Push front",
+    "push_middle_int": "Push middle",
+    "ascending_sawtooth_int": "Ascending sawtooth",
+    "descending_sawtooth_int": "Descending sawtooth",
+    "alternating_int": "Alternating",
+    "alternating_16_values_int": "Alternating (16 values)"
+}
+
+for filename in os.listdir("profiles"):
+    data = {}
+    for line in open(os.path.join("profiles", filename)):
+        size, distribution, algo, *results = line.split()
+        size = int(size)
+        distribution = distribution_names[distribution]
+        results = [int(result) for result in results]
+        if not size in data: data[size] = {}
+        if not distribution in data[size]: data[size][distribution] = {}
+        data[size][distribution][algo] = results
+
+    size = 10**6
+    distributions = (
+        "Shuffled",
+        "Shuffled (16 values)",
+        "All equal",
+        "Ascending",
+        "Descending",
+        "Pipe organ",
+        "Push front",
+        "Push middle",
+        "Ascending sawtooth",
+        "Descending sawtooth",
+        "Alternating",
+        "Alternating (16 values)"
+    )
+
+    algos = ("heapsort", "introsort", "pdqsort", "vergesort", "timsort")
+
+    groupnames = distributions
+    groupsize = len(algos)
+    groups = [[data[size][distribution][algo] for algo in algos] for distribution in distributions]
+    barwidth = 0.6
+    spacing = 1
+    groupwidth = groupsize * barwidth + spacing
+
+    colors = ["#1f77b4", "#aec7e8", "#ff7f0e", "#ffbb78", "#800080"]
+    for i, algo in enumerate(algos):
+        heights = [numpy.median(data[size][distribution][algo]) for distribution in distributions]
+        errors = [numpy.std(data[size][distribution][algo]) for distribution in distributions]
+        plt.barh([barwidth*i + groupwidth*n for n in range(len(distributions))],
+                 heights, 0.6, color = colors[i], label = algo)
+
+    # Set axes limits and labels.
+    plt.yticks([barwidth * groupsize/2 + groupwidth*n for n in range(len(groupnames))], groupnames)
+    plt.xlabel("Cycles per element")
+
+    # Turn off ticks for y-axis.
+    plt.tick_params(
+        axis="y",
+        which="both",
+        left="off",
+        right="off",
+        labelleft="on"
+    )
+
+    ax = plt.gca()
+    ax.invert_yaxis()
+    ax.relim()
+    ax.autoscale_view()
+    plt.ylim(plt.ylim()[0]+1, plt.ylim()[1]-1)
+    plt.legend(loc="lower right")
+
+    plt.title("Sorting $10^{}$elements".format(round(math.log(size, 10))))
+
+    figure = plt.gcf() # get current figure
+    figure.set_size_inches(8*.75, 6*.75)
+    plt.show()
+    plt.savefig(os.path.join("plots", os.path.splitext(filename)[0] + ".png"), dpi = 100, bbox_inches="tight")
+
+    plt.clf()

--- a/benchmarks/bench.cpp
+++ b/benchmarks/bench.cpp
@@ -1,0 +1,186 @@
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <chrono>
+#include <ctime>
+#include <functional>
+#include <iostream>
+#include <random>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#include <cpp-sort/sorters.h>
+
+#ifdef _WIN32
+    #include <intrin.h>
+    #define rdtsc __rdtsc
+#else
+    #ifdef __i386__
+        static __inline__ unsigned long long rdtsc() {
+            unsigned long long int x;
+            __asm__ volatile(".byte 0x0f, 0x31" : "=A" (x));
+            return x;
+        }
+    #elif defined(__x86_64__)
+        static __inline__ unsigned long long rdtsc(){
+            unsigned hi, lo;
+            __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+            return ((unsigned long long) lo) | (((unsigned long long) hi) << 32);
+        }
+    #else
+        #error no rdtsc implementation
+    #endif
+#endif
+
+
+inline std::vector<int> shuffled_int(size_t size, std::mt19937_64& rng) {
+    std::vector<int> v; v.reserve(size);
+    for (int i = 0; i < size; ++i) v.push_back(i);
+    std::shuffle(v.begin(), v.end(), rng);
+    return v;
+}
+
+inline std::vector<int> shuffled_16_values_int(size_t size, std::mt19937_64& rng) {
+    std::vector<int> v; v.reserve(size);
+    for (int i = 0; i < size; ++i) v.push_back(i % 16);
+    std::shuffle(v.begin(), v.end(), rng);
+    return v;
+}
+
+inline std::vector<int> all_equal_int(size_t size, std::mt19937_64&) {
+    std::vector<int> v; v.reserve(size);
+    for (int i = 0; i < size; ++i) v.push_back(0);
+    return v;
+}
+
+inline std::vector<int> ascending_int(size_t size, std::mt19937_64&) {
+    std::vector<int> v; v.reserve(size);
+    for (int i = 0; i < size; ++i) v.push_back(i);
+    return v;
+}
+
+inline std::vector<int> descending_int(size_t size, std::mt19937_64&) {
+    std::vector<int> v; v.reserve(size);
+    for (int i = size - 1; i >= 0; --i) v.push_back(i);
+    return v;
+}
+
+inline std::vector<int> pipe_organ_int(size_t size, std::mt19937_64&) {
+    std::vector<int> v; v.reserve(size);
+    for (int i = 0; i < size/2; ++i) v.push_back(i);
+    for (int i = size/2; i < size; ++i) v.push_back(size - i);
+    return v;
+}
+
+inline std::vector<int> push_front_int(size_t size, std::mt19937_64&) {
+    std::vector<int> v; v.reserve(size);
+    for (int i = 1; i < size; ++i) v.push_back(i);
+    v.push_back(0);
+    return v;
+}
+
+inline std::vector<int> push_middle_int(size_t size, std::mt19937_64&) {
+    std::vector<int> v; v.reserve(size);
+    for (int i = 0; i < size; ++i) {
+        if (i != size/2) v.push_back(i);
+    }
+    v.push_back(size/2);
+    return v;
+}
+
+inline std::vector<int> ascending_sawtooth_int(size_t size, std::mt19937_64&) {
+    std::vector<int> v; v.reserve(size);
+    int limit = size / log2(size) * 1.1;
+    for (int i = 0; i < size; ++i) v.push_back(i % limit);
+    return v;
+}
+
+inline std::vector<int> descending_sawtooth_int(size_t size, std::mt19937_64&) {
+    std::vector<int> v; v.reserve(size);
+    int limit = size / log2(size) * 1.1;
+    for (int i = size - 1; i >= 0; --i) v.push_back(i % limit);
+    return v;
+}
+
+inline std::vector<int> alternating_int(size_t size, std::mt19937_64&) {
+    std::vector<int> v; v.reserve(size);
+    for (int i = 0; i < size; ++i) v.push_back(i);
+    for (int i = 0; i < size; i += 2) v[i] *= -1;
+    return v;
+}
+
+inline std::vector<int> alternating_16_values_int(size_t size, std::mt19937_64&) {
+    std::vector<int> v; v.reserve(size);
+    for (int i = 0; i < size; ++i) v.push_back(i % 16);
+    for (int i = 0; i < size; i += 2) v[i] *= -1;
+    return v;
+}
+
+
+
+int main()
+{
+    auto seed = std::time(0);
+    std::mt19937_64 el;
+
+    using DistrF    = std::vector<int>(*)(size_t, std::mt19937_64&);
+    using SortF     = void(*)(std::vector<int>&);
+
+    std::pair<std::string, DistrF> distributions[] = {
+        { "shuffled_int",               shuffled_int                },
+        { "shuffled_16_values_int",     shuffled_16_values_int      },
+        { "all_equal_int",              all_equal_int               },
+        { "ascending_int",              ascending_int               },
+        { "descending_int",             descending_int              },
+        { "pipe_organ_int",             pipe_organ_int              },
+        { "push_front_int",             push_front_int              },
+        { "push_middle_int",            push_middle_int             },
+        { "ascending_sawtooth_int",     ascending_sawtooth_int      },
+        { "descending_sawtooth_int",    descending_sawtooth_int     },
+        { "alternating_int",            alternating_int             },
+        { "alternating_16_values_int",  alternating_16_values_int   }
+    };
+
+    std::pair<std::string, SortF> sorts[] = {
+        { "heapsort",   cppsort::heap_sorter()  },
+        { "introsort",  cppsort::std_sorter()   },
+        { "pdqsort",    cppsort::pdq_sorter()   },
+        { "vergesort",  cppsort::verge_sorter() },
+        { "timsort",    cppsort::tim_sorter()   }
+    };
+
+    int sizes[] = { 1'000'000 };
+
+    for (auto& distribution : distributions) {
+        for (auto& sort : sorts) {
+            el.seed(seed);
+
+            for (auto size : sizes) {
+                std::chrono::time_point<std::chrono::high_resolution_clock> total_start, total_end;
+                std::vector<uint64_t> cycles;
+
+                total_start = std::chrono::high_resolution_clock::now();
+                total_end = std::chrono::high_resolution_clock::now();
+                while (std::chrono::duration_cast<std::chrono::milliseconds>(total_end - total_start).count() < 10000) {
+                    std::vector<int> vec = distribution.second(size, el);
+                    uint64_t start = rdtsc();
+                    sort.second(vec);
+                    uint64_t end = rdtsc();
+                    assert(std::is_sorted(vec.begin(), vec.end()));
+                    cycles.push_back(double(end - start) / size + 0.5);
+                    total_end = std::chrono::high_resolution_clock::now();
+                }
+
+                std::sort(cycles.begin(), cycles.end());
+
+                std::cerr << size << " " << distribution.first << " " << sort.first << "\n";
+                std::cout << size << " " << distribution.first << " " << sort.first << " ";
+                for (uint64_t cycle : cycles) std::cout << cycle << " ";
+                std::cout << "\n";
+            }
+        }
+    }
+
+    return 0;
+}

--- a/doc/sorters.md
+++ b/doc/sorters.md
@@ -9,24 +9,31 @@ object, where a type satisfies the `ForwardIterable` concept if and only if call
 to `std::begin` and `std::end` on this object return instances of a type satisfying
 the [`ForwardIterator`](http://en.cppreference.com/w/cpp/concept/ForwardIterator)
 concept (since the iterable is sorted in-place and thus altered, sorting an
-`InputIterable` type is not possible).
+`InputIterable` type is not possible). A `Sorter` instance should additionally be
+convertible to `Ret(*)(ForwardIterable&)` where `Ret` is the return type of the
+operation.
 
 A type satisfies the `ComparisonSorter` concept if it satisfies the `Sorter`
 concept and can additionally be called with a second parameter satisfying the
 [`Compare`](http://en.cppreference.com/w/cpp/concept/Compare) concept. While
 most sorters satisfy this concept, some of them might implement non-comparison
 based sorting algorithms such as radix sort, and thus only satisfy the `Sorter`
-concept.
+concept. A `ComparisonSorter` instance should additionally be convertible to
+`Ret(*)(ForwardIterable&, Compare)` where `Ret` is the return type of the
+operation.
 
 Implementing a sorter is easy once you have a sorting algorithm: simply add an
 `operator()` overload that forwards its values to a sorting function.
 
 ```cpp
+#include <cpp-sort/sorter_base.h>
+
 /**
  * ComparisonSorter implementing a spam_sort algorithm, where spam_sort
  * is a sorting algorithm working with bidirectional iterators.
  */
-struct spam_sorter
+struct spam_sorter:
+    cppsort::sorter_base<spam_sorter>
 {
     template<typename BidirectionalIterable, typename Compare>
     auto operator()(BidirectionalIterable& iterable, Compare cmp) const
@@ -36,6 +43,9 @@ struct spam_sorter
     }
 };
 ```
+
+In the previous example, `sorter_base` is a CRTP base class that is used to provide
+the function pointer conversion operators to the sorter.
 
 While these function objects offer little more than regular sorting functions by
 themselves, you can use them together with [*sorter adapaters*](sorter-adapters.md)

--- a/include/cpp-sort/adapters/counting_adapter.h
+++ b/include/cpp-sort/adapters/counting_adapter.h
@@ -29,9 +29,9 @@
 ////////////////////////////////////////////////////////////
 #include <cstddef>
 #include <functional>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
 #include "../detail/comparison_counter.h"
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -43,7 +43,7 @@ namespace cppsort
         typename CountType = std::size_t
     >
     struct counting_adapter:
-        detail::sorter_base<counting_adapter<Sorter, CountType>>
+        sorter_base<counting_adapter<Sorter, CountType>>
     {
         template<
             typename Iterable,

--- a/include/cpp-sort/adapters/counting_adapter.h
+++ b/include/cpp-sort/adapters/counting_adapter.h
@@ -31,6 +31,7 @@
 #include <functional>
 #include <cpp-sort/sorter_traits.h>
 #include "../detail/comparison_counter.h"
+#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -41,7 +42,8 @@ namespace cppsort
         typename Sorter,
         typename CountType = std::size_t
     >
-    struct counting_adapter
+    struct counting_adapter:
+        detail::sorter_base<counting_adapter<Sorter, CountType>>
     {
         template<
             typename Iterable,

--- a/include/cpp-sort/adapters/hybrid_adapter.h
+++ b/include/cpp-sort/adapters/hybrid_adapter.h
@@ -32,6 +32,7 @@
 #include <type_traits>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/any_all.h>
+#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -39,7 +40,8 @@ namespace cppsort
     // Adapter
 
     template<typename... Sorters>
-    class hybrid_adapter
+    class hybrid_adapter:
+        detail::sorter_base<hybrid_adapter<Sorters...>>
     {
         private:
 

--- a/include/cpp-sort/adapters/hybrid_adapter.h
+++ b/include/cpp-sort/adapters/hybrid_adapter.h
@@ -30,9 +30,9 @@
 #include <functional>
 #include <iterator>
 #include <type_traits>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/any_all.h>
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -41,7 +41,7 @@ namespace cppsort
 
     template<typename... Sorters>
     class hybrid_adapter:
-        detail::sorter_base<hybrid_adapter<Sorters...>>
+        sorter_base<hybrid_adapter<Sorters...>>
     {
         private:
 

--- a/include/cpp-sort/adapters/self_sort_adapter.h
+++ b/include/cpp-sort/adapters/self_sort_adapter.h
@@ -29,8 +29,9 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <type_traits>
+#include <cpp-sort/sorter_base.h>
+#include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/has_sort_method.h>
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -39,7 +40,7 @@ namespace cppsort
 
     template<typename Sorter>
     struct self_sort_adapter:
-        detail::sorter_base<self_sort_adapter<Sorter>>
+        sorter_base<self_sort_adapter<Sorter>>
     {
         template<
             typename Iterable,

--- a/include/cpp-sort/adapters/self_sort_adapter.h
+++ b/include/cpp-sort/adapters/self_sort_adapter.h
@@ -30,6 +30,7 @@
 #include <functional>
 #include <type_traits>
 #include <cpp-sort/utility/has_sort_method.h>
+#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -37,7 +38,8 @@ namespace cppsort
     // Adapter
 
     template<typename Sorter>
-    struct self_sort_adapter
+    struct self_sort_adapter:
+        detail::sorter_base<self_sort_adapter<Sorter>>
     {
         template<
             typename Iterable,

--- a/include/cpp-sort/adapters/small_array_adapter.h
+++ b/include/cpp-sort/adapters/small_array_adapter.h
@@ -35,6 +35,7 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/is_in_pack.h>
 #include "../detail/sort_n.h"
+#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -48,7 +49,8 @@ namespace cppsort
         typename Sorter,
         std::size_t... Indices
     >
-    struct small_array_adapter<Sorter, std::index_sequence<Indices...>>
+    struct small_array_adapter<Sorter, std::index_sequence<Indices...>>:
+        detail::sorter_base<small_array_adapter<Sorter, std::index_sequence<Indices...>>>
     {
         template<
             typename RandomAccessIterable,

--- a/include/cpp-sort/adapters/small_array_adapter.h
+++ b/include/cpp-sort/adapters/small_array_adapter.h
@@ -32,10 +32,10 @@
 #include <functional>
 #include <type_traits>
 #include <utility>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/is_in_pack.h>
 #include "../detail/sort_n.h"
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -50,7 +50,7 @@ namespace cppsort
         std::size_t... Indices
     >
     struct small_array_adapter<Sorter, std::index_sequence<Indices...>>:
-        detail::sorter_base<small_array_adapter<Sorter, std::index_sequence<Indices...>>>
+        sorter_base<small_array_adapter<Sorter, std::index_sequence<Indices...>>>
     {
         template<
             typename RandomAccessIterable,

--- a/include/cpp-sort/detail/sorter_base.h
+++ b/include/cpp-sort/detail/sorter_base.h
@@ -28,6 +28,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <cstddef>
+#include <type_traits>
 
 namespace cppsort
 {
@@ -43,10 +44,10 @@ namespace detail
         protected:
 
             template<typename Iterable>
-            using fptr_t = void(*)(Iterable&);
+            using fptr_t = std::result_of_t<Sorter(Iterable&)>(*)(Iterable&);
 
             template<typename Iterable, typename Compare>
-            using fptr_cmp_t = void(*)(Iterable&, Compare);
+            using fptr_cmp_t = std::result_of_t<Sorter(Iterable&, Compare)>(*)(Iterable&, Compare);
 
         public:
 
@@ -54,7 +55,7 @@ namespace detail
             operator fptr_t<Iterable>() const
             {
                 return [](Iterable& iterable) {
-                    Sorter{}(iterable);
+                    return Sorter{}(iterable);
                 };
             }
 
@@ -62,7 +63,7 @@ namespace detail
             operator fptr_cmp_t<Iterable, Compare>() const
             {
                 return [](Iterable& iterable, Compare compare) {
-                    Sorter{}(iterable, compare);
+                    return Sorter{}(iterable, compare);
                 };
             }
     };

--- a/include/cpp-sort/sorter_base.h
+++ b/include/cpp-sort/sorter_base.h
@@ -21,8 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef CPPSORT_DETAIL_SORTER_BASE_H_
-#define CPPSORT_DETAIL_SORTER_BASE_H_
+#ifndef CPPSORT_SORTER_BASE_H_
+#define CPPSORT_SORTER_BASE_H_
 
 ////////////////////////////////////////////////////////////
 // Headers
@@ -31,8 +31,6 @@
 #include <type_traits>
 
 namespace cppsort
-{
-namespace detail
 {
     // This class is a CRTP base class whose sorters inherit
     // from which gives them the ability to convert to function
@@ -67,6 +65,6 @@ namespace detail
                 };
             }
     };
-}}
+}
 
-#endif // CPPSORT_DETAIL_SORTER_BASE_H_
+#endif // CPPSORT_SORTER_BASE_H_

--- a/include/cpp-sort/sorters/heap_sorter.h
+++ b/include/cpp-sort/sorters/heap_sorter.h
@@ -37,17 +37,52 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    struct heap_sorter
+    class heap_sorter
     {
-        template<
-            typename RandomAccessIterable,
-            typename Compare = std::less<>
-        >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-            -> void
-        {
-            detail::heapsort(std::begin(iterable), std::end(iterable), compare);
-        }
+        private:
+
+            ////////////////////////////////////////////////////////////
+            // Function pointer aliases
+
+            template<typename RandomAccessIterable>
+            using fptr_t = void(*)(RandomAccessIterable&);
+
+            template<typename RandomAccessIterable, typename Compare>
+            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
+
+        public:
+
+            ////////////////////////////////////////////////////////////
+            // operator()
+
+            template<
+                typename RandomAccessIterable,
+                typename Compare = std::less<>
+            >
+            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+                -> void
+            {
+                detail::heapsort(std::begin(iterable), std::end(iterable), compare);
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Conversion to function pointer
+
+            template<typename RandomAccessIterable>
+            operator fptr_t<RandomAccessIterable>() const
+            {
+                return [](RandomAccessIterable& iterable) {
+                    detail::heapsort(std::begin(iterable), std::end(iterable), std::less<>{});
+                };
+            }
+
+            template<typename RandomAccessIterable, typename Compare>
+            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
+            {
+                return [](RandomAccessIterable& iterable, Compare compare) {
+                    detail::heapsort(std::begin(iterable), std::end(iterable), compare);
+                };
+            }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/heap_sorter.h
+++ b/include/cpp-sort/sorters/heap_sorter.h
@@ -29,9 +29,9 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
 #include "../detail/heapsort.h"
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -39,7 +39,7 @@ namespace cppsort
     // Sorter
 
     struct heap_sorter:
-        detail::sorter_base<heap_sorter>
+        sorter_base<heap_sorter>
     {
         template<
             typename RandomAccessIterable,

--- a/include/cpp-sort/sorters/heap_sorter.h
+++ b/include/cpp-sort/sorters/heap_sorter.h
@@ -31,58 +31,25 @@
 #include <iterator>
 #include <cpp-sort/sorter_traits.h>
 #include "../detail/heapsort.h"
+#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    class heap_sorter
+    struct heap_sorter:
+        detail::sorter_base<heap_sorter>
     {
-        private:
-
-            ////////////////////////////////////////////////////////////
-            // Function pointer aliases
-
-            template<typename RandomAccessIterable>
-            using fptr_t = void(*)(RandomAccessIterable&);
-
-            template<typename RandomAccessIterable, typename Compare>
-            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
-
-        public:
-
-            ////////////////////////////////////////////////////////////
-            // operator()
-
-            template<
-                typename RandomAccessIterable,
-                typename Compare = std::less<>
-            >
-            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-                -> void
-            {
-                detail::heapsort(std::begin(iterable), std::end(iterable), compare);
-            }
-
-            ////////////////////////////////////////////////////////////
-            // Conversion to function pointer
-
-            template<typename RandomAccessIterable>
-            operator fptr_t<RandomAccessIterable>() const
-            {
-                return [](RandomAccessIterable& iterable) {
-                    detail::heapsort(std::begin(iterable), std::end(iterable), std::less<>{});
-                };
-            }
-
-            template<typename RandomAccessIterable, typename Compare>
-            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
-            {
-                return [](RandomAccessIterable& iterable, Compare compare) {
-                    detail::heapsort(std::begin(iterable), std::end(iterable), compare);
-                };
-            }
+        template<
+            typename RandomAccessIterable,
+            typename Compare = std::less<>
+        >
+        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+            -> void
+        {
+            detail::heapsort(std::begin(iterable), std::end(iterable), compare);
+        }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/inplace_merge_sorter.h
+++ b/include/cpp-sort/sorters/inplace_merge_sorter.h
@@ -29,10 +29,10 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/size.h>
 #include "../detail/inplace_merge_sort.h"
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -40,7 +40,7 @@ namespace cppsort
     // Sorter
 
     struct inplace_merge_sorter:
-        detail::sorter_base<inplace_merge_sorter>
+        sorter_base<inplace_merge_sorter>
     {
         template<
             typename ForwardIterable,

--- a/include/cpp-sort/sorters/inplace_merge_sorter.h
+++ b/include/cpp-sort/sorters/inplace_merge_sorter.h
@@ -38,22 +38,63 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    struct inplace_merge_sorter
+    class inplace_merge_sorter
     {
-        template<
-            typename ForwardIterable,
-            typename Compare = std::less<>
-        >
-        auto operator()(ForwardIterable& iterable, Compare compare={}) const
-            -> void
-        {
-            detail::inplace_merge_sort(
-                std::begin(iterable),
-                std::end(iterable),
-                compare,
-                utility::size(iterable)
-            );
-        }
+        private:
+
+            ////////////////////////////////////////////////////////////
+            // Function pointer aliases
+
+            template<typename ForwardIterable>
+            using fptr_t = void(*)(ForwardIterable&);
+
+            template<typename ForwardIterable, typename Compare>
+            using fptr_cmp_t = void(*)(ForwardIterable&, Compare);
+
+        public:
+
+            ////////////////////////////////////////////////////////////
+            // operator()
+
+            template<
+                typename ForwardIterable,
+                typename Compare = std::less<>
+            >
+            auto operator()(ForwardIterable& iterable, Compare compare={}) const
+                -> void
+            {
+                detail::inplace_merge_sort(
+                    std::begin(iterable),
+                    std::end(iterable),
+                    compare,
+                    utility::size(iterable)
+                );
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Conversion to function pointer
+
+            template<typename ForwardIterable>
+            operator fptr_t<ForwardIterable>() const
+            {
+                return [](ForwardIterable& iterable) {
+                    detail::inplace_merge_sort(
+                        std::begin(iterable), std::end(iterable),
+                        std::less<>{}, utility::size(iterable)
+                    );
+                };
+            }
+
+            template<typename ForwardIterable, typename Compare>
+            operator fptr_cmp_t<ForwardIterable, Compare>() const
+            {
+                return [](ForwardIterable& iterable, Compare compare) {
+                    detail::inplace_merge_sort(
+                        std::begin(iterable), std::end(iterable),
+                        compare, utility::size(iterable)
+                    );
+                };
+            }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/inplace_merge_sorter.h
+++ b/include/cpp-sort/sorters/inplace_merge_sorter.h
@@ -32,69 +32,30 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/size.h>
 #include "../detail/inplace_merge_sort.h"
+#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    class inplace_merge_sorter
+    struct inplace_merge_sorter:
+        detail::sorter_base<inplace_merge_sorter>
     {
-        private:
-
-            ////////////////////////////////////////////////////////////
-            // Function pointer aliases
-
-            template<typename ForwardIterable>
-            using fptr_t = void(*)(ForwardIterable&);
-
-            template<typename ForwardIterable, typename Compare>
-            using fptr_cmp_t = void(*)(ForwardIterable&, Compare);
-
-        public:
-
-            ////////////////////////////////////////////////////////////
-            // operator()
-
-            template<
-                typename ForwardIterable,
-                typename Compare = std::less<>
-            >
-            auto operator()(ForwardIterable& iterable, Compare compare={}) const
-                -> void
-            {
-                detail::inplace_merge_sort(
-                    std::begin(iterable),
-                    std::end(iterable),
-                    compare,
-                    utility::size(iterable)
-                );
-            }
-
-            ////////////////////////////////////////////////////////////
-            // Conversion to function pointer
-
-            template<typename ForwardIterable>
-            operator fptr_t<ForwardIterable>() const
-            {
-                return [](ForwardIterable& iterable) {
-                    detail::inplace_merge_sort(
-                        std::begin(iterable), std::end(iterable),
-                        std::less<>{}, utility::size(iterable)
-                    );
-                };
-            }
-
-            template<typename ForwardIterable, typename Compare>
-            operator fptr_cmp_t<ForwardIterable, Compare>() const
-            {
-                return [](ForwardIterable& iterable, Compare compare) {
-                    detail::inplace_merge_sort(
-                        std::begin(iterable), std::end(iterable),
-                        compare, utility::size(iterable)
-                    );
-                };
-            }
+        template<
+            typename ForwardIterable,
+            typename Compare = std::less<>
+        >
+        auto operator()(ForwardIterable& iterable, Compare compare={}) const
+            -> void
+        {
+            detail::inplace_merge_sort(
+                std::begin(iterable),
+                std::end(iterable),
+                compare,
+                utility::size(iterable)
+            );
+        }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -31,58 +31,25 @@
 #include <iterator>
 #include <cpp-sort/sorter_traits.h>
 #include "../detail/insertion_sort.h"
+#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    class insertion_sorter
+    struct insertion_sorter:
+        detail::sorter_base<insertion_sorter>
     {
-        private:
-
-            ////////////////////////////////////////////////////////////
-            // Function pointer aliases
-
-            template<typename BidirectionalIterable>
-            using fptr_t = void(*)(BidirectionalIterable&);
-
-            template<typename BidirectionalIterable, typename Compare>
-            using fptr_cmp_t = void(*)(BidirectionalIterable&, Compare);
-
-        public:
-
-            ////////////////////////////////////////////////////////////
-            // operator()
-
-            template<
-                typename BidirectionalIterable,
-                typename Compare = std::less<>
-            >
-            auto operator()(BidirectionalIterable& iterable, Compare compare={}) const
-                -> void
-            {
-                detail::insertion_sort(std::begin(iterable), std::end(iterable), compare);
-            }
-
-            ////////////////////////////////////////////////////////////
-            // Conversion to function pointer
-
-            template<typename BidirectionalIterable>
-            operator fptr_t<BidirectionalIterable>() const
-            {
-                return [](BidirectionalIterable& iterable) {
-                    detail::insertion_sort(std::begin(iterable), std::end(iterable), std::less<>{});
-                };
-            }
-
-            template<typename BidirectionalIterable, typename Compare>
-            operator fptr_cmp_t<BidirectionalIterable, Compare>() const
-            {
-                return [](BidirectionalIterable& iterable, Compare compare) {
-                    detail::insertion_sort(std::begin(iterable), std::end(iterable), compare);
-                };
-            }
+        template<
+            typename BidirectionalIterable,
+            typename Compare = std::less<>
+        >
+        auto operator()(BidirectionalIterable& iterable, Compare compare={}) const
+            -> void
+        {
+            detail::insertion_sort(std::begin(iterable), std::end(iterable), compare);
+        }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -29,9 +29,9 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
 #include "../detail/insertion_sort.h"
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -39,7 +39,7 @@ namespace cppsort
     // Sorter
 
     struct insertion_sorter:
-        detail::sorter_base<insertion_sorter>
+        sorter_base<insertion_sorter>
     {
         template<
             typename BidirectionalIterable,

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -37,17 +37,52 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    struct insertion_sorter
+    class insertion_sorter
     {
-        template<
-            typename BidirectionalIterable,
-            typename Compare = std::less<>
-        >
-        auto operator()(BidirectionalIterable& iterable, Compare compare={}) const
-            -> void
-        {
-            detail::insertion_sort(std::begin(iterable), std::end(iterable), compare);
-        }
+        private:
+
+            ////////////////////////////////////////////////////////////
+            // Function pointer aliases
+
+            template<typename BidirectionalIterable>
+            using fptr_t = void(*)(BidirectionalIterable&);
+
+            template<typename BidirectionalIterable, typename Compare>
+            using fptr_cmp_t = void(*)(BidirectionalIterable&, Compare);
+
+        public:
+
+            ////////////////////////////////////////////////////////////
+            // operator()
+
+            template<
+                typename BidirectionalIterable,
+                typename Compare = std::less<>
+            >
+            auto operator()(BidirectionalIterable& iterable, Compare compare={}) const
+                -> void
+            {
+                detail::insertion_sort(std::begin(iterable), std::end(iterable), compare);
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Conversion to function pointer
+
+            template<typename BidirectionalIterable>
+            operator fptr_t<BidirectionalIterable>() const
+            {
+                return [](BidirectionalIterable& iterable) {
+                    detail::insertion_sort(std::begin(iterable), std::end(iterable), std::less<>{});
+                };
+            }
+
+            template<typename BidirectionalIterable, typename Compare>
+            operator fptr_cmp_t<BidirectionalIterable, Compare>() const
+            {
+                return [](BidirectionalIterable& iterable, Compare compare) {
+                    detail::insertion_sort(std::begin(iterable), std::end(iterable), compare);
+                };
+            }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -31,58 +31,25 @@
 #include <iterator>
 #include <cpp-sort/sorter_traits.h>
 #include "../detail/merge_sort.h"
+#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    class merge_sorter
+    struct merge_sorter:
+        detail::sorter_base<merge_sorter>
     {
-        private:
-
-            ////////////////////////////////////////////////////////////
-            // Function pointer aliases
-
-            template<typename RandomAccessIterable>
-            using fptr_t = void(*)(RandomAccessIterable&);
-
-            template<typename RandomAccessIterable, typename Compare>
-            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
-
-        public:
-
-            ////////////////////////////////////////////////////////////
-            // operator()
-
-            template<
-                typename RandomAccessIterable,
-                typename Compare = std::less<>
-            >
-            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-                -> void
-            {
-                detail::merge_sort(std::begin(iterable), std::end(iterable), compare);
-            }
-
-            ////////////////////////////////////////////////////////////
-            // Conversion to function pointer
-
-            template<typename RandomAccessIterable>
-            operator fptr_t<RandomAccessIterable>() const
-            {
-                return [](RandomAccessIterable& iterable) {
-                    detail::merge_sort(std::begin(iterable), std::end(iterable), std::less<>{});
-                };
-            }
-
-            template<typename RandomAccessIterable, typename Compare>
-            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
-            {
-                return [](RandomAccessIterable& iterable, Compare compare) {
-                    detail::merge_sort(std::begin(iterable), std::end(iterable), compare);
-                };
-            }
+        template<
+            typename RandomAccessIterable,
+            typename Compare = std::less<>
+        >
+        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+            -> void
+        {
+            detail::merge_sort(std::begin(iterable), std::end(iterable), compare);
+        }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -37,17 +37,52 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    struct merge_sorter
+    class merge_sorter
     {
-        template<
-            typename RandomAccessIterable,
-            typename Compare = std::less<>
-        >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-            -> void
-        {
-            detail::merge_sort(std::begin(iterable), std::end(iterable), compare);
-        }
+        private:
+
+            ////////////////////////////////////////////////////////////
+            // Function pointer aliases
+
+            template<typename RandomAccessIterable>
+            using fptr_t = void(*)(RandomAccessIterable&);
+
+            template<typename RandomAccessIterable, typename Compare>
+            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
+
+        public:
+
+            ////////////////////////////////////////////////////////////
+            // operator()
+
+            template<
+                typename RandomAccessIterable,
+                typename Compare = std::less<>
+            >
+            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+                -> void
+            {
+                detail::merge_sort(std::begin(iterable), std::end(iterable), compare);
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Conversion to function pointer
+
+            template<typename RandomAccessIterable>
+            operator fptr_t<RandomAccessIterable>() const
+            {
+                return [](RandomAccessIterable& iterable) {
+                    detail::merge_sort(std::begin(iterable), std::end(iterable), std::less<>{});
+                };
+            }
+
+            template<typename RandomAccessIterable, typename Compare>
+            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
+            {
+                return [](RandomAccessIterable& iterable, Compare compare) {
+                    detail::merge_sort(std::begin(iterable), std::end(iterable), compare);
+                };
+            }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -29,9 +29,9 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
 #include "../detail/merge_sort.h"
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -39,7 +39,7 @@ namespace cppsort
     // Sorter
 
     struct merge_sorter:
-        detail::sorter_base<merge_sorter>
+        sorter_base<merge_sorter>
     {
         template<
             typename RandomAccessIterable,

--- a/include/cpp-sort/sorters/pdq_sorter.h
+++ b/include/cpp-sort/sorters/pdq_sorter.h
@@ -37,17 +37,52 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    struct pdq_sorter
+    class pdq_sorter
     {
-        template<
-            typename RandomAccessIterable,
-            typename Compare = std::less<>
-        >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-            -> void
-        {
-            detail::pdqsort(std::begin(iterable), std::end(iterable), compare);
-        }
+        private:
+
+            ////////////////////////////////////////////////////////////
+            // Function pointer aliases
+
+            template<typename RandomAccessIterable>
+            using fptr_t = void(*)(RandomAccessIterable&);
+
+            template<typename RandomAccessIterable, typename Compare>
+            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
+
+        public:
+
+            ////////////////////////////////////////////////////////////
+            // operator()
+
+            template<
+                typename RandomAccessIterable,
+                typename Compare = std::less<>
+            >
+            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+                -> void
+            {
+                detail::pdqsort(std::begin(iterable), std::end(iterable), compare);
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Conversion to function pointer
+
+            template<typename RandomAccessIterable>
+            operator fptr_t<RandomAccessIterable>() const
+            {
+                return [](RandomAccessIterable& iterable) {
+                    detail::pdqsort(std::begin(iterable), std::end(iterable), std::less<>{});
+                };
+            }
+
+            template<typename RandomAccessIterable, typename Compare>
+            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
+            {
+                return [](RandomAccessIterable& iterable, Compare compare) {
+                    detail::pdqsort(std::begin(iterable), std::end(iterable), compare);
+                };
+            }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/pdq_sorter.h
+++ b/include/cpp-sort/sorters/pdq_sorter.h
@@ -29,9 +29,9 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
 #include "../detail/pdqsort.h"
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -39,7 +39,7 @@ namespace cppsort
     // Sorter
 
     struct pdq_sorter:
-        detail::sorter_base<pdq_sorter>
+        sorter_base<pdq_sorter>
     {
         template<
             typename RandomAccessIterable,

--- a/include/cpp-sort/sorters/pdq_sorter.h
+++ b/include/cpp-sort/sorters/pdq_sorter.h
@@ -31,58 +31,25 @@
 #include <iterator>
 #include <cpp-sort/sorter_traits.h>
 #include "../detail/pdqsort.h"
+#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    class pdq_sorter
+    struct pdq_sorter:
+        detail::sorter_base<pdq_sorter>
     {
-        private:
-
-            ////////////////////////////////////////////////////////////
-            // Function pointer aliases
-
-            template<typename RandomAccessIterable>
-            using fptr_t = void(*)(RandomAccessIterable&);
-
-            template<typename RandomAccessIterable, typename Compare>
-            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
-
-        public:
-
-            ////////////////////////////////////////////////////////////
-            // operator()
-
-            template<
-                typename RandomAccessIterable,
-                typename Compare = std::less<>
-            >
-            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-                -> void
-            {
-                detail::pdqsort(std::begin(iterable), std::end(iterable), compare);
-            }
-
-            ////////////////////////////////////////////////////////////
-            // Conversion to function pointer
-
-            template<typename RandomAccessIterable>
-            operator fptr_t<RandomAccessIterable>() const
-            {
-                return [](RandomAccessIterable& iterable) {
-                    detail::pdqsort(std::begin(iterable), std::end(iterable), std::less<>{});
-                };
-            }
-
-            template<typename RandomAccessIterable, typename Compare>
-            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
-            {
-                return [](RandomAccessIterable& iterable, Compare compare) {
-                    detail::pdqsort(std::begin(iterable), std::end(iterable), compare);
-                };
-            }
+        template<
+            typename RandomAccessIterable,
+            typename Compare = std::less<>
+        >
+        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+            -> void
+        {
+            detail::pdqsort(std::begin(iterable), std::end(iterable), compare);
+        }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/quick_sorter.h
+++ b/include/cpp-sort/sorters/quick_sorter.h
@@ -38,22 +38,63 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    struct quick_sorter
+    class quick_sorter
     {
-        template<
-            typename BidirectionalIterable,
-            typename Compare = std::less<>
-        >
-        auto operator()(BidirectionalIterable& iterable, Compare compare={}) const
-            -> void
-        {
-            detail::quicksort(
-                std::begin(iterable),
-                std::end(iterable),
-                compare,
-                utility::size(iterable)
-            );
-        }
+        private:
+
+            ////////////////////////////////////////////////////////////
+            // Function pointer aliases
+
+            template<typename BidirectionalIterable>
+            using fptr_t = void(*)(BidirectionalIterable&);
+
+            template<typename BidirectionalIterable, typename Compare>
+            using fptr_cmp_t = void(*)(BidirectionalIterable&, Compare);
+
+        public:
+
+            ////////////////////////////////////////////////////////////
+            // operator()
+
+            template<
+                typename BidirectionalIterable,
+                typename Compare = std::less<>
+            >
+            auto operator()(BidirectionalIterable& iterable, Compare compare={}) const
+                -> void
+            {
+                detail::quicksort(
+                    std::begin(iterable),
+                    std::end(iterable),
+                    compare,
+                    utility::size(iterable)
+                );
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Conversion to function pointer
+
+            template<typename BidirectionalIterable>
+            operator fptr_t<BidirectionalIterable>() const
+            {
+                return [](BidirectionalIterable& iterable) {
+                    detail::quicksort(
+                        std::begin(iterable), std::end(iterable),
+                        std::less<>{}, utility::size(iterable)
+                    );
+                };
+            }
+
+            template<typename BidirectionalIterable, typename Compare>
+            operator fptr_cmp_t<BidirectionalIterable, Compare>() const
+            {
+                return [](BidirectionalIterable& iterable, Compare compare) {
+                    detail::quicksort(
+                        std::begin(iterable), std::end(iterable),
+                        compare, utility::size(iterable)
+                    );
+                };
+            }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/quick_sorter.h
+++ b/include/cpp-sort/sorters/quick_sorter.h
@@ -29,10 +29,10 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/size.h>
 #include "../detail/quicksort.h"
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -40,7 +40,7 @@ namespace cppsort
     // Sorter
 
     struct quick_sorter:
-        detail::sorter_base<quick_sorter>
+        sorter_base<quick_sorter>
     {
         template<
             typename BidirectionalIterable,

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -30,8 +30,8 @@
 #include <algorithm>
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
-#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
@@ -39,7 +39,7 @@ namespace cppsort
     // Sorter
 
     struct std_sorter:
-        detail::sorter_base<std_sorter>
+        sorter_base<std_sorter>
     {
         template<
             typename RandomAccessIterable,

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -31,58 +31,25 @@
 #include <functional>
 #include <iterator>
 #include <cpp-sort/sorter_traits.h>
+#include "../detail/sorter_base.h"
 
 namespace cppsort
 {
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    class std_sorter
+    struct std_sorter:
+        detail::sorter_base<std_sorter>
     {
-        private:
-
-            ////////////////////////////////////////////////////////////
-            // Function pointer aliases
-
-            template<typename RandomAccessIterable>
-            using fptr_t = void(*)(RandomAccessIterable&);
-
-            template<typename RandomAccessIterable, typename Compare>
-            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
-
-        public:
-
-            ////////////////////////////////////////////////////////////
-            // operator()
-
-            template<
-                typename RandomAccessIterable,
-                typename Compare = std::less<>
-            >
-            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-                -> void
-            {
-                std::sort(std::begin(iterable), std::end(iterable), compare);
-            }
-
-            ////////////////////////////////////////////////////////////
-            // Conversion to function pointer
-
-            template<typename RandomAccessIterable>
-            operator fptr_t<RandomAccessIterable>() const
-            {
-                return [](RandomAccessIterable& iterable) {
-                    std::sort(std::begin(iterable), std::end(iterable));
-                };
-            }
-
-            template<typename RandomAccessIterable, typename Compare>
-            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
-            {
-                return [](RandomAccessIterable& iterable, Compare compare) {
-                    std::sort(std::begin(iterable), std::end(iterable), compare);
-                };
-            }
+        template<
+            typename RandomAccessIterable,
+            typename Compare = std::less<>
+        >
+        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+            -> void
+        {
+            std::sort(std::begin(iterable), std::end(iterable), compare);
+        }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -37,17 +37,52 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    struct std_sorter
+    class std_sorter
     {
-        template<
-            typename RandomAccessIterable,
-            typename Compare = std::less<>
-        >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-            -> void
-        {
-            std::sort(std::begin(iterable), std::end(iterable), compare);
-        }
+        private:
+
+            ////////////////////////////////////////////////////////////
+            // Function pointer aliases
+
+            template<typename RandomAccessIterable>
+            using fptr_t = void(*)(RandomAccessIterable&);
+
+            template<typename RandomAccessIterable, typename Compare>
+            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
+
+        public:
+
+            ////////////////////////////////////////////////////////////
+            // operator()
+
+            template<
+                typename RandomAccessIterable,
+                typename Compare = std::less<>
+            >
+            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+                -> void
+            {
+                std::sort(std::begin(iterable), std::end(iterable), compare);
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Conversion to function pointer
+
+            template<typename RandomAccessIterable>
+            operator fptr_t<RandomAccessIterable>() const
+            {
+                return [](RandomAccessIterable& iterable) {
+                    std::sort(std::begin(iterable), std::end(iterable));
+                };
+            }
+
+            template<typename RandomAccessIterable, typename Compare>
+            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
+            {
+                return [](RandomAccessIterable& iterable, Compare compare) {
+                    std::sort(std::begin(iterable), std::end(iterable), compare);
+                };
+            }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -29,8 +29,8 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
-#include "../detail/sorter_base.h"
 #include "../detail/timsort.h"
 
 namespace cppsort
@@ -39,7 +39,7 @@ namespace cppsort
     // Sorter
 
     struct tim_sorter:
-        detail::sorter_base<tim_sorter>
+        sorter_base<tim_sorter>
     {
         template<
             typename RandomAccessIterable,

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -37,17 +37,52 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    struct tim_sorter
+    class tim_sorter
     {
-        template<
-            typename RandomAccessIterable,
-            typename Compare = std::less<>
-        >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-            -> void
-        {
-            detail::timsort(std::begin(iterable), std::end(iterable), compare);
-        }
+        private:
+
+            ////////////////////////////////////////////////////////////
+            // Function pointer aliases
+
+            template<typename RandomAccessIterable>
+            using fptr_t = void(*)(RandomAccessIterable&);
+
+            template<typename RandomAccessIterable, typename Compare>
+            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
+
+        public:
+
+            ////////////////////////////////////////////////////////////
+            // operator()
+
+            template<
+                typename RandomAccessIterable,
+                typename Compare = std::less<>
+            >
+            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+                -> void
+            {
+                detail::timsort(std::begin(iterable), std::end(iterable), compare);
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Conversion to function pointer
+
+            template<typename RandomAccessIterable>
+            operator fptr_t<RandomAccessIterable>() const
+            {
+                return [](RandomAccessIterable& iterable) {
+                    detail::timsort(std::begin(iterable), std::end(iterable), std::less<>{});
+                };
+            }
+
+            template<typename RandomAccessIterable, typename Compare>
+            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
+            {
+                return [](RandomAccessIterable& iterable, Compare compare) {
+                    detail::timsort(std::begin(iterable), std::end(iterable), compare);
+                };
+            }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -30,6 +30,7 @@
 #include <functional>
 #include <iterator>
 #include <cpp-sort/sorter_traits.h>
+#include "../detail/sorter_base.h"
 #include "../detail/timsort.h"
 
 namespace cppsort
@@ -37,52 +38,18 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    class tim_sorter
+    struct tim_sorter:
+        detail::sorter_base<tim_sorter>
     {
-        private:
-
-            ////////////////////////////////////////////////////////////
-            // Function pointer aliases
-
-            template<typename RandomAccessIterable>
-            using fptr_t = void(*)(RandomAccessIterable&);
-
-            template<typename RandomAccessIterable, typename Compare>
-            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
-
-        public:
-
-            ////////////////////////////////////////////////////////////
-            // operator()
-
-            template<
-                typename RandomAccessIterable,
-                typename Compare = std::less<>
-            >
-            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-                -> void
-            {
-                detail::timsort(std::begin(iterable), std::end(iterable), compare);
-            }
-
-            ////////////////////////////////////////////////////////////
-            // Conversion to function pointer
-
-            template<typename RandomAccessIterable>
-            operator fptr_t<RandomAccessIterable>() const
-            {
-                return [](RandomAccessIterable& iterable) {
-                    detail::timsort(std::begin(iterable), std::end(iterable), std::less<>{});
-                };
-            }
-
-            template<typename RandomAccessIterable, typename Compare>
-            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
-            {
-                return [](RandomAccessIterable& iterable, Compare compare) {
-                    detail::timsort(std::begin(iterable), std::end(iterable), compare);
-                };
-            }
+        template<
+            typename RandomAccessIterable,
+            typename Compare = std::less<>
+        >
+        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+            -> void
+        {
+            detail::timsort(std::begin(iterable), std::end(iterable), compare);
+        }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/verge_sorter.h
+++ b/include/cpp-sort/sorters/verge_sorter.h
@@ -29,8 +29,8 @@
 ////////////////////////////////////////////////////////////
 #include <functional>
 #include <iterator>
+#include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
-#include "../detail/sorter_base.h"
 #include "../detail/vergesort.h"
 
 namespace cppsort
@@ -39,7 +39,7 @@ namespace cppsort
     // Sorter
 
     struct verge_sorter:
-        detail::sorter_base<verge_sorter>
+        sorter_base<verge_sorter>
     {
         template<
             typename RandomAccessIterable,

--- a/include/cpp-sort/sorters/verge_sorter.h
+++ b/include/cpp-sort/sorters/verge_sorter.h
@@ -37,17 +37,52 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    struct verge_sorter
+    class verge_sorter
     {
-        template<
-            typename RandomAccessIterable,
-            typename Compare = std::less<>
-        >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-            -> void
-        {
-            detail::vergesort(std::begin(iterable), std::end(iterable), compare);
-        }
+        private:
+
+            ////////////////////////////////////////////////////////////
+            // Function pointer aliases
+
+            template<typename RandomAccessIterable>
+            using fptr_t = void(*)(RandomAccessIterable&);
+
+            template<typename RandomAccessIterable, typename Compare>
+            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
+
+        public:
+
+            ////////////////////////////////////////////////////////////
+            // operator()
+
+            template<
+                typename RandomAccessIterable,
+                typename Compare = std::less<>
+            >
+            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+                -> void
+            {
+                detail::vergesort(std::begin(iterable), std::end(iterable), compare);
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Conversion to function pointer
+
+            template<typename RandomAccessIterable>
+            operator fptr_t<RandomAccessIterable>() const
+            {
+                return [](RandomAccessIterable& iterable) {
+                    detail::vergesort(std::begin(iterable), std::end(iterable), std::less<>{});
+                };
+            }
+
+            template<typename RandomAccessIterable, typename Compare>
+            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
+            {
+                return [](RandomAccessIterable& iterable, Compare compare) {
+                    detail::vergesort(std::begin(iterable), std::end(iterable), compare);
+                };
+            }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/verge_sorter.h
+++ b/include/cpp-sort/sorters/verge_sorter.h
@@ -30,6 +30,7 @@
 #include <functional>
 #include <iterator>
 #include <cpp-sort/sorter_traits.h>
+#include "../detail/sorter_base.h"
 #include "../detail/vergesort.h"
 
 namespace cppsort
@@ -37,52 +38,18 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter
 
-    class verge_sorter
+    struct verge_sorter:
+        detail::sorter_base<verge_sorter>
     {
-        private:
-
-            ////////////////////////////////////////////////////////////
-            // Function pointer aliases
-
-            template<typename RandomAccessIterable>
-            using fptr_t = void(*)(RandomAccessIterable&);
-
-            template<typename RandomAccessIterable, typename Compare>
-            using fptr_cmp_t = void(*)(RandomAccessIterable&, Compare);
-
-        public:
-
-            ////////////////////////////////////////////////////////////
-            // operator()
-
-            template<
-                typename RandomAccessIterable,
-                typename Compare = std::less<>
-            >
-            auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
-                -> void
-            {
-                detail::vergesort(std::begin(iterable), std::end(iterable), compare);
-            }
-
-            ////////////////////////////////////////////////////////////
-            // Conversion to function pointer
-
-            template<typename RandomAccessIterable>
-            operator fptr_t<RandomAccessIterable>() const
-            {
-                return [](RandomAccessIterable& iterable) {
-                    detail::vergesort(std::begin(iterable), std::end(iterable), std::less<>{});
-                };
-            }
-
-            template<typename RandomAccessIterable, typename Compare>
-            operator fptr_cmp_t<RandomAccessIterable, Compare>() const
-            {
-                return [](RandomAccessIterable& iterable, Compare compare) {
-                    detail::vergesort(std::begin(iterable), std::end(iterable), compare);
-                };
-            }
+        template<
+            typename RandomAccessIterable,
+            typename Compare = std::less<>
+        >
+        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+            -> void
+        {
+            detail::vergesort(std::begin(iterable), std::end(iterable), compare);
+        }
     };
 
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add a `cppsort::sorter_base` class tempate and use it almost everywhere to add to the sorters and sorter adapters the possibiity to be converted to several kinds of function pointers. It allows for unary and binary function pointers conversions through the use of captureless lambdas (with or without `Compare`). Update documentation accordingly.