### PR TITLE
Iterator interface for sorters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,17 @@ int main()
 }
 ```
 
-**cpp-sort** also provides *sorters* as well as *sorter adapters* which can
-be used by `cppsort::sort` to sort a collection. It is possible to get some
-information about the sorters and sorter adapters with *sorter traits*.
-Everything lives in the `cppsort` namespace. You can read more about the
-available sorting tools in the documentation:
+**cpp-sort** also provides *sorters* as well as *sorter adapters* which can be
+used by `cppsort::sort` to sort a collection, as well as a sorter base class to
+ease the construction of new sorters. It is possible to get some information
+about the sorters and sorter adapters thanks to *sorter traits*. Everything lives
+in the `cppsort` namespace. You can read more about the available sorting tools
+in the documentation:
 
 * [`cppsort::sort`](doc/sort.md)
 * [Sorters](doc/sorters.md)
 * [Sorter adapters](doc/sorter-adapters.md)
+* [Sorter base](doc/sorter-base.md)
 * [Sorter traits](doc/sorter-traits.md)
 
 There are also a few other utilities used by the library and made available

--- a/doc/sort.md
+++ b/doc/sort.md
@@ -1,7 +1,9 @@
 # `cppsort::sort`
 
 `cppsort::sort` has several overloads. Some take a [sorter](sorters.md) to sort
-the given iterable while others call the library's default sorter instead:
+the given iterable while others call the library's default sorter instead. It is
+designed so that it is possible to pass either a collection so sort or a pair of
+iterators.
 
 ```cpp
 template<typename Iterable>
@@ -11,17 +13,22 @@ auto sort(Iterable& iterable)
 template<typename Iterable, typename Compare>
 auto sort(Iterable& iterable, Compare compare)
     -> void;
+
+template<typename Iterator>
+auto sort(Iterator first, Iterator last)
+    -> void;
+
+template<typename Iterator, typename Compare>
+auto sort(Iterator first, Iterator last, Compare compare)
+    -> void;
 ```
 
-These overloads take an `Iterable` collection and sort it in-place in ascending order
-using `cppsort::default_sorter` to perform the sort. The comparator `compare` is used
-if provided.
+These overloads take an `Iterable` or a pair of `Iterator` and sort the corresponding
+collection in-place in ascending order using `cppsort::default_sorter` to perform the
+sort. The comparator `compare` is used if provided.
 
 ```cpp 
-template<
-    typename Iterable,
-    typename Sorter
->
+template<typename Iterable, typename Sorter>
 auto sort(Iterable& iterable, const Sorter& sorter)
     -> decltype(auto);
 
@@ -32,12 +39,27 @@ template<
 >
 auto sort(Iterable& iterable, const ComparisonSorter& sorter, Compare compare)
     -> decltype(auto);
+
+template<typename Iterator, typename Sorter>
+auto sort(Iterator first, Iterator last, const Sorter& sorter)
+    -> decltype(auto);
+
+template<
+    typename Iterator,
+    typename ComparisonSorter,
+    typename Compare
+>
+auto sort(Iterator first, Iterator last,
+          const ComparisonSorter& sorter,
+          Compare compare)
+    -> decltype(auto);
 ```
 
-These overloads take an `Iterable` collection and sort it in-place in ascending order
-using the given sorter. The comparator `compare` is used if provided and if the sorter
-satisfies the `ComparisonSorter` concept. The value returned corresponds to the value
-returned when applying the sorter to the iterable.
+These overloads take an `Iterable` or a pair of `Iterator` and sort the corresponding
+collection in-place in ascending order using the given sorter. The comparator `compare`
+is used if provided and if the sorter satisfies the `ComparisonSorter` concept. The
+value returned corresponds to the value returned when applying the sorter to the given
+parameters.
 
 Note that there is some SFINAE magic happening to ensure that none of the overloads
 are ambiguous. This magic has been stripped from the documentation for clarity.

--- a/doc/sorter-adapters.md
+++ b/doc/sorter-adapters.md
@@ -4,7 +4,7 @@ Sorter adapters are the main reason for using sorter function objects instead
 of regular functions. A *sorter adapter* is a class template that takes another
 `Sorter` template parameter and alters its behavior. The resulting class can be
 used as a regular sorter, and be adapted in turn. It is possible to include all
-the available adapters at once with the following line:
+the available adapters at once with the following directive:
 
 ```cpp
 #include <cpp-sort/adapters.h>

--- a/doc/sorter-base.md
+++ b/doc/sorter-base.md
@@ -1,0 +1,70 @@
+# Sorter base
+
+The [`Sorter`](sorters.md) and `ComparisonSorter` require sorter implementers
+to implement a variety of methods (up to eight) with a redundancy factor that
+can be rather high. Therefore, **cpp-sort** provides a CRTP base class which
+makes creating sorters easier by generating most of the required operations
+in the simplest cases.
+
+`sorter_base` provides the following functions so that a sorter can be turned
+into a function pointer:
+
+```cpp
+template<typename Iterable>
+operator Ret(*)(Iterable&)() const;
+
+template<typename Iterable, typename Compare>
+operator Ret(*)(Iterable&, Compare)() const;
+
+template<typename Iterator>
+operator Ret(*)(Iterator, Iterator)() const;
+
+template<typename Iterator, typename Compare>
+operator Ret(*)(Iterator, Iterator, Compare)() const;
+```
+
+Note that the syntax is made up, but it allows to clearly highlight what it
+does while hiding the ugly `typedef`s needed for the syntax to be valid. In
+these signatures, `Ret` is an `std::result_of_t` of the parameters (well, it
+is what you would expect it to be).
+
+The following overloads of `operator()` are implemented in `sorter_base`:
+
+```cpp
+template<typename Iterable>
+auto operator()(Iterable& iterable) const
+    -> decltype(auto);
+
+template<typename Iterable, typename Compare>
+auto operator()(Iterable& iterable, Compare compare) const
+    -> decltype(auto);
+```
+
+This overload simply call the `operator()` overloads taking two iterators
+by using `std::begin` and `std::end` on `iterable`. When implementing your
+own sorters, these overload will be hidden by default but you can import
+them in the class with a `using` directive.
+
+Provided you have a sorting function with a standard iterator interface,
+creating the corresponding sorter becomes trivial thanks to `sorter_base`.
+For instance, here is a simple sorter wrapping `std::sorter`:
+
+```cpp
+struct std_sorter:
+    cppsort::sorter_base<std_sorter>
+{
+    using cppsort::sorter_base<std_sorter>::operator();
+
+    template<
+        typename RandomAccessIterator,
+        typename Compare = std::less<>
+    >
+    auto operator()(RandomAccessIterator first,
+                    RandomAccessIterator last,
+                    Compare compare={}) const
+        -> void
+    {
+        std::sort(first, last, compare);
+    }
+};
+```

--- a/doc/sorter-traits.md
+++ b/doc/sorter-traits.md
@@ -4,7 +4,7 @@
 #include <cpp-sort/sorter_traits.h>
 ```
 
-### `is_sorter` and `is_comparison_sorter`
+### `is_sorter` and friends
 
 These variable templates `is_sorter<typename Sorter, typename Iterable>` and
 `is_comparison_sorter<typename Sorter, typename Iterable, typename Compare>`
@@ -22,6 +22,18 @@ constexpr bool is_sorter = /* implementation-defined */;
 
 template<typename Sorter, typename Iterable, typename Compare>
 constexpr bool is_comparison_sorter = /* implementation-defined */;
+```
+
+There are also variants of these variable templates which take a potential
+sorter type and an iterator type. These exist to check whether the sorter
+can be called with a pair of iterators.
+
+```cpp
+template<typename Sorter, typename Iterator>
+constexpr bool is_sorter_iterator = /* implementation-defined */;
+
+template<typename Sorter, typename Iterator, typename Compare>
+constexpr bool is_comparison_sorter_iterator = /* implementation-defined */;
 ```
 
 ### `sorter_traits`

--- a/include/cpp-sort/adapters/counting_adapter.h
+++ b/include/cpp-sort/adapters/counting_adapter.h
@@ -45,15 +45,17 @@ namespace cppsort
     struct counting_adapter:
         sorter_base<counting_adapter<ComparisonSorter, CountType>>
     {
+        using sorter_base<counting_adapter<ComparisonSorter, CountType>>::operator();
+
         template<
-            typename Iterable,
+            typename Iterator,
             typename Compare = std::less<>
         >
-        auto operator()(Iterable& iterable, Compare compare={}) const
+        auto operator()(Iterator first, Iterator last, Compare compare={}) const
             -> CountType
         {
             detail::comparison_counter<Compare, CountType> cmp(compare);
-            ComparisonSorter{}(iterable, cmp);
+            ComparisonSorter{}(first, last, cmp);
             return cmp.count;
         }
     };

--- a/include/cpp-sort/adapters/hybrid_adapter.h
+++ b/include/cpp-sort/adapters/hybrid_adapter.h
@@ -79,21 +79,20 @@ namespace cppsort
 
         public:
 
-            template<typename Iterable, typename... Args>
-            auto operator()(Iterable& iterable, Args&&... args) const
+            using sorter_base<hybrid_adapter<Sorters...>>::operator();
+
+            template<typename Iterator, typename... Args>
+            auto operator()(Iterator first, Iterator last, Args&&... args) const
                 -> void
             {
                 // Dispatch-enabled sorter
                 using sorter = sorters_merger<category_wrapper<Sorters>...>;
 
                 // Iterator category of the iterable to sort
-                using category =
-                    typename std::iterator_traits<
-                        decltype(std::begin(iterable))
-                    >::iterator_category;
+                using category = typename std::iterator_traits<Iterator>::iterator_category;
 
                 // Call the appropriate operator()
-                sorter{}(category{}, iterable, std::forward<Args>(args)...);
+                sorter{}(category{}, first, last, std::forward<Args>(args)...);
             }
     };
 

--- a/include/cpp-sort/adapters/self_sort_adapter.h
+++ b/include/cpp-sort/adapters/self_sort_adapter.h
@@ -68,6 +68,20 @@ namespace cppsort
         {
             Sorter{}(iterable, compare);
         }
+
+        template<typename Iterator>
+        auto operator()(Iterator first, Iterator last) const
+            -> void
+        {
+            Sorter{}(first, last);
+        }
+
+        template<typename Iterator, typename Compare>
+        auto operator()(Iterator first, Iterator last, Compare compare) const
+            -> void
+        {
+            Sorter{}(first, last, compare);
+        }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/adapters/small_array_adapter.h
+++ b/include/cpp-sort/adapters/small_array_adapter.h
@@ -66,6 +66,20 @@ namespace cppsort
             Sorter{}(iterable, compare);
         }
 
+        template<typename Iterator>
+        auto operator()(Iterator first, Iterator last) const
+            -> void
+        {
+            Sorter{}(first, last);
+        }
+
+        template<typename Iterator, typename Compare>
+        auto operator()(Iterator first, Iterator last, Compare compare) const
+            -> void
+        {
+            Sorter{}(first, last, compare);
+        }
+
         template<
             typename T,
             std::size_t N,

--- a/include/cpp-sort/sort.h
+++ b/include/cpp-sort/sort.h
@@ -51,6 +51,24 @@ namespace cppsort
         default_sorter{}(iterable, compare);
     }
 
+    template<typename Iterator>
+    auto sort(Iterator first, Iterator last)
+        -> void
+    {
+        default_sorter{}(first, last);
+    }
+
+    template<
+        typename Iterator,
+        typename Compare,
+        typename = std::enable_if_t<not is_sorter_iterator<Compare, Iterator>>
+    >
+    auto sort(Iterator first, Iterator last, Compare compare)
+        -> void
+    {
+        default_sorter{}(first, last, compare);
+    }
+
     template<
         typename Iterable,
         typename Sorter,
@@ -71,6 +89,28 @@ namespace cppsort
         -> decltype(auto)
     {
         return sorter(iterable, compare);
+    }
+
+    template<
+        typename Iterator,
+        typename Sorter,
+        typename = std::enable_if_t<is_sorter_iterator<Sorter, Iterator>>
+    >
+    auto sort(Iterator first, Iterator last, const Sorter& sorter)
+        -> decltype(auto)
+    {
+        return sorter(first, last);
+    }
+
+    template<
+        typename Iterator,
+        typename ComparisonSorter,
+        typename Compare
+    >
+    auto sort(Iterator first, Iterator last, const ComparisonSorter& sorter, Compare compare)
+        -> decltype(auto)
+    {
+        return sorter(first, last, compare);
     }
 }
 

--- a/include/cpp-sort/sorter_base.h
+++ b/include/cpp-sort/sorter_base.h
@@ -27,7 +27,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <cstddef>
+#include <iterator>
 #include <type_traits>
 
 namespace cppsort
@@ -41,13 +41,25 @@ namespace cppsort
     {
         protected:
 
+            ////////////////////////////////////////////////////////////
+            // Function pointer types
+
             template<typename Iterable>
             using fptr_t = std::result_of_t<Sorter(Iterable&)>(*)(Iterable&);
 
             template<typename Iterable, typename Compare>
             using fptr_cmp_t = std::result_of_t<Sorter(Iterable&, Compare)>(*)(Iterable&, Compare);
 
+            template<typename Iterator>
+            using fptr_it_t = std::result_of_t<Sorter(Iterator, Iterator)>(*)(Iterator, Iterator);
+
+            template<typename Iterator, typename Compare>
+            using fptr_cmp_it_t = std::result_of_t<Sorter(Iterator, Iterator, Compare)>(*)(Iterator, Iterator, Compare);
+
         public:
+
+            ////////////////////////////////////////////////////////////
+            // Conversion to function pointers
 
             template<typename Iterable>
             operator fptr_t<Iterable>() const
@@ -63,6 +75,39 @@ namespace cppsort
                 return [](Iterable& iterable, Compare compare) {
                     return Sorter{}(iterable, compare);
                 };
+            }
+
+            template<typename Iterator>
+            operator fptr_it_t<Iterator>() const
+            {
+                return [](Iterator first, Iterator last) {
+                    return Sorter{}(first, last);
+                };
+            }
+
+            template<typename Iterator, typename Compare>
+            operator fptr_cmp_it_t<Iterator, Compare>() const
+            {
+                return [](Iterator first, Iterator last, Compare compare) {
+                    return Sorter{}(first, last, compare);
+                };
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Automatic iterable sorting interface
+
+            template<typename Iterable>
+            auto operator()(Iterable& iterable) const
+                -> decltype(auto)
+            {
+                return Sorter{}(std::begin(iterable), std::end(iterable));
+            }
+
+            template<typename Iterable, typename Compare>
+            auto operator()(Iterable& iterable, Compare compare) const
+                -> decltype(auto)
+            {
+                return Sorter{}(std::begin(iterable), std::end(iterable), compare);
             }
     };
 }

--- a/include/cpp-sort/sorter_traits.h
+++ b/include/cpp-sort/sorter_traits.h
@@ -37,11 +37,39 @@ namespace cppsort
 
     namespace detail
     {
+        // Group two iterators as a range, used to discriminate
+        // sorters from comparison functions
+        template<typename Iterator>
+        class range
+        {
+            public:
+
+                range(Iterator begin, Iterator end):
+                    _begin(begin),
+                    _end(end)
+                {}
+
+                Iterator begin() { return _begin; }
+                Iterator end() { return _end; }
+                Iterator begin() const { return _begin; }
+                Iterator end() const { return _end; }
+
+            private:
+
+                Iterator _begin, _end;
+        };
+
         template<typename Sorter, typename Iterable>
         using is_sorter_t = std::result_of_t<Sorter(Iterable&)>;
 
         template<typename Sorter, typename Iterable, typename Compare>
         using is_comparison_sorter_t = std::result_of_t<Sorter(Iterable&, Compare)>;
+
+        template<typename Sorter, typename Iterator>
+        using is_sorter_iterator_t = is_sorter_t<Sorter, range<Iterator>>;
+
+        template<typename Sorter, typename Iterator, typename Compare>
+        using is_comparison_sorter_iterator_t = is_comparison_sorter_t<Sorter, range<Iterator>, Compare>;
     }
 
     template<typename Sorter, typename Iterable>
@@ -52,6 +80,15 @@ namespace cppsort
     constexpr bool is_comparison_sorter
         = is_sorter<Sorter, Iterable> &&
           utility::is_detected_v<detail::is_comparison_sorter_t, Sorter, Iterable, Compare>;
+
+    template<typename Sorter, typename Iterator>
+    constexpr bool is_sorter_iterator
+        = utility::is_detected_v<detail::is_sorter_iterator_t, Sorter, Iterator>;
+
+    template<typename Sorter, typename Iterator, typename Compare>
+    constexpr bool is_comparison_sorter_iterator
+        = is_sorter_iterator<Sorter, Iterator> &&
+          utility::is_detected_v<detail::is_comparison_sorter_iterator_t, Sorter, Iterator, Compare>;
 
     ////////////////////////////////////////////////////////////
     // Sorter traits

--- a/include/cpp-sort/sorters/heap_sorter.h
+++ b/include/cpp-sort/sorters/heap_sorter.h
@@ -41,14 +41,18 @@ namespace cppsort
     struct heap_sorter:
         sorter_base<heap_sorter>
     {
+        using sorter_base<heap_sorter>::operator();
+
         template<
-            typename RandomAccessIterable,
+            typename RandomAccessIterator,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+        auto operator()(RandomAccessIterator first,
+                        RandomAccessIterator last,
+                        Compare compare={}) const
             -> void
         {
-            detail::heapsort(std::begin(iterable), std::end(iterable), compare);
+            detail::heapsort(first, last, compare);
         }
     };
 

--- a/include/cpp-sort/sorters/inplace_merge_sorter.h
+++ b/include/cpp-sort/sorters/inplace_merge_sorter.h
@@ -56,6 +56,22 @@ namespace cppsort
                 utility::size(iterable)
             );
         }
+
+        template<
+            typename ForwardIterator,
+            typename Compare = std::less<>
+        >
+        auto operator()(ForwardIterator first,
+                        ForwardIterator last,
+                        Compare compare={}) const
+            -> void
+        {
+            detail::inplace_merge_sort(
+                first, last,
+                compare,
+                std::distance(first, last)
+            );
+        }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -41,14 +41,18 @@ namespace cppsort
     struct insertion_sorter:
         sorter_base<insertion_sorter>
     {
+        using sorter_base<insertion_sorter>::operator();
+
         template<
-            typename BidirectionalIterable,
+            typename BidirectionalIterator,
             typename Compare = std::less<>
         >
-        auto operator()(BidirectionalIterable& iterable, Compare compare={}) const
+        auto operator()(BidirectionalIterator first,
+                        BidirectionalIterator last,
+                        Compare compare={}) const
             -> void
         {
-            detail::insertion_sort(std::begin(iterable), std::end(iterable), compare);
+            detail::insertion_sort(first, last, compare);
         }
     };
 

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -41,14 +41,18 @@ namespace cppsort
     struct merge_sorter:
         sorter_base<merge_sorter>
     {
+        using sorter_base<merge_sorter>::operator();
+
         template<
-            typename RandomAccessIterable,
+            typename RandomAccessIterator,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+        auto operator()(RandomAccessIterator first,
+                        RandomAccessIterator last,
+                        Compare compare={}) const
             -> void
         {
-            detail::merge_sort(std::begin(iterable), std::end(iterable), compare);
+            detail::merge_sort(first, last, compare);
         }
     };
 

--- a/include/cpp-sort/sorters/pdq_sorter.h
+++ b/include/cpp-sort/sorters/pdq_sorter.h
@@ -41,14 +41,18 @@ namespace cppsort
     struct pdq_sorter:
         sorter_base<pdq_sorter>
     {
+        using sorter_base<pdq_sorter>::operator();
+
         template<
-            typename RandomAccessIterable,
+            typename RandomAccessIterator,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+        auto operator()(RandomAccessIterator first,
+                        RandomAccessIterator last,
+                        Compare compare={}) const
             -> void
         {
-            detail::pdqsort(std::begin(iterable), std::end(iterable), compare);
+            detail::pdqsort(first, last, compare);
         }
     };
 

--- a/include/cpp-sort/sorters/quick_sorter.h
+++ b/include/cpp-sort/sorters/quick_sorter.h
@@ -56,6 +56,22 @@ namespace cppsort
                 utility::size(iterable)
             );
         }
+
+        template<
+            typename BidirectionalIterator,
+            typename Compare = std::less<>
+        >
+        auto operator()(BidirectionalIterator first,
+                        BidirectionalIterator last,
+                        Compare compare={}) const
+            -> void
+        {
+            detail::quicksort(
+                first, last,
+                compare,
+                std::distance(first, last)
+            );
+        }
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -41,14 +41,18 @@ namespace cppsort
     struct std_sorter:
         sorter_base<std_sorter>
     {
+        using sorter_base<std_sorter>::operator();
+
         template<
-            typename RandomAccessIterable,
+            typename RandomAccessIterator,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+        auto operator()(RandomAccessIterator first,
+                        RandomAccessIterator last,
+                        Compare compare={}) const
             -> void
         {
-            std::sort(std::begin(iterable), std::end(iterable), compare);
+            std::sort(first, last, compare);
         }
     };
 

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -41,14 +41,18 @@ namespace cppsort
     struct tim_sorter:
         sorter_base<tim_sorter>
     {
+        using sorter_base<tim_sorter>::operator();
+
         template<
-            typename RandomAccessIterable,
+            typename RandomAccessIterator,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+        auto operator()(RandomAccessIterator first,
+                        RandomAccessIterator last,
+                        Compare compare={}) const
             -> void
         {
-            detail::timsort(std::begin(iterable), std::end(iterable), compare);
+            detail::timsort(first, last, compare);
         }
     };
 

--- a/include/cpp-sort/sorters/verge_sorter.h
+++ b/include/cpp-sort/sorters/verge_sorter.h
@@ -41,14 +41,18 @@ namespace cppsort
     struct verge_sorter:
         sorter_base<verge_sorter>
     {
+        using sorter_base<verge_sorter>::operator();
+
         template<
-            typename RandomAccessIterable,
+            typename RandomAccessIterator,
             typename Compare = std::less<>
         >
-        auto operator()(RandomAccessIterable& iterable, Compare compare={}) const
+        auto operator()(RandomAccessIterator first,
+                        RandomAccessIterator last,
+                        Compare compare={}) const
             -> void
         {
-            detail::vergesort(std::begin(iterable), std::end(iterable), compare);
+            detail::vergesort(first, last, compare);
         }
     };
 


### PR DESCRIPTION
This update adds an iterator interface to every sorter and sorter adapter in the library. It also mandates that types satisfying the `Sorter` and `ComparisonSorter` concepts shall be callable with a pair of iterators so that they can sort more than full collections.

The update also introduces `sorter_base`, a CRTP class design to ease the writing of simpe sorters. Most of the sorters available in the library make use of this class to reduce boilerplate.