### PR TITLE
Allow to use comparison function objects a tags

### DIFF
--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
     cpp-sort-testsuite
 
     main.cpp
+    sorter_base_std_less.cpp
     ${ADAPTER_TESTS}
     ${SORTERS_TESTS}
 )

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(${CATCH_INCLUDE_DIR})
 set(
     ADAPTER_TESTS
 
+    adapters/hybrid_adapter_partial_compare.cpp
     adapters/hybrid_adapter_sfinae.cpp
     adapters/self_sort_adapter_no_compare.cpp
     adapters/small_array_adapter3.cpp

--- a/testsuite/adapters/hybrid_adapter_partial_compare.cpp
+++ b/testsuite/adapters/hybrid_adapter_partial_compare.cpp
@@ -1,0 +1,139 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <functional>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorter_base.h>
+
+enum struct sorter_type
+{
+    ascending,
+    descending,
+    generic
+};
+
+struct partial_comparison_sorter:
+    cppsort::sorter_base<partial_comparison_sorter>
+{
+    using cppsort::sorter_base<partial_comparison_sorter>::operator();
+
+    // Sort in ascending order
+    template<typename Iterator>
+    auto operator()(Iterator, Iterator) const
+        -> sorter_type
+    {
+        return sorter_type::ascending;
+    }
+
+    // Sort in descending order
+    template<typename Iterator>
+    auto operator()(Iterator, Iterator, std::greater<>) const
+        -> sorter_type
+    {
+        return sorter_type::descending;
+    }
+};
+
+struct generic_sorter:
+    cppsort::sorter_base<generic_sorter>
+{
+    using cppsort::sorter_base<generic_sorter>::operator();
+
+    template<typename Iterator, typename Compare>
+    auto operator()(Iterator, Iterator, Compare)
+        -> sorter_type
+    {
+        return sorter_type::generic;
+    }
+};
+
+namespace cppsort
+{
+    template<>
+    struct sorter_traits<partial_comparison_sorter>
+    {
+        using iterator_category = std::random_access_iterator_tag;
+        static constexpr bool is_stable = false;
+    };
+
+    template<>
+    struct sorter_traits<generic_sorter>
+    {
+        using iterator_category = std::forward_iterator_tag;
+        static constexpr bool is_stable = true;
+    };
+}
+
+TEST_CASE( "hybrid_adapter over partial comparison sorter",
+           "[hybrid_adapter][compare]" )
+{
+    // Check that hybrid_adapter works as expected even
+    // with partial comparison sorters
+
+    using sorter = cppsort::hybrid_adapter<
+        partial_comparison_sorter,
+        generic_sorter
+    >;
+
+    // Vector to "sort"
+    std::vector<int> vec(3);
+
+    SECTION( "without a comparison function" )
+    {
+        sorter_type res1 = cppsort::sort(vec, sorter{});
+        CHECK( res1 == sorter_type::ascending );
+
+        sorter_type res2 = cppsort::sort(std::begin(vec), std::end(vec), sorter{});
+        CHECK( res2 == sorter_type::ascending );
+    }
+
+    SECTION( "with std::less<>" )
+    {
+        sorter_type res1 = cppsort::sort(vec, sorter{}, std::less<>{});
+        CHECK( res1 == sorter_type::ascending );
+
+        sorter_type res2 = cppsort::sort(std::begin(vec), std::end(vec), sorter{}, std::less<>{});
+        CHECK( res2 == sorter_type::ascending );
+    }
+
+    SECTION( "with std::greater<>" )
+    {
+        sorter_type res1 = cppsort::sort(vec, sorter{}, std::greater<>{});
+        CHECK( res1 == sorter_type::descending );
+
+        sorter_type res2 = cppsort::sort(std::begin(vec), std::end(vec), sorter{}, std::greater<>{});
+        CHECK( res2 == sorter_type::descending );
+    }
+
+    SECTION( "with another functor" )
+    {
+        sorter_type res1 = cppsort::sort(vec, sorter{}, std::less_equal<>{});
+        CHECK( res1 == sorter_type::generic );
+
+        sorter_type res2 = cppsort::sort(std::begin(vec), std::end(vec), sorter{}, std::less_equal<>{});
+        CHECK( res2 == sorter_type::generic );
+    }
+}

--- a/testsuite/adapters/hybrid_adapter_sfinae.cpp
+++ b/testsuite/adapters/hybrid_adapter_sfinae.cpp
@@ -25,11 +25,11 @@
 #include <string>
 #include <type_traits>
 #include <vector>
-#include <catch.hpp>
 #include <cpp-sort/adapters/hybrid_adapter.h>
 #include <cpp-sort/sort.h>
 #include <cpp-sort/sorter_base.h>
 #include <cpp-sort/sorter_traits.h>
+#include <catch.hpp>
 
 // Type of sorter used for checks
 enum class sorter_type

--- a/testsuite/sorter_base_std_less.cpp
+++ b/testsuite/sorter_base_std_less.cpp
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <cassert>
+#include <iterator>
+#include <string>
+#include <type_traits>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorter_base.h>
+
+struct comparison_sorter:
+    cppsort::sorter_base<comparison_sorter>
+{
+    using cppsort::sorter_base<comparison_sorter>::operator();
+
+    template<typename Iterator, typename Compare>
+    auto operator()(Iterator, Iterator, Compare) const
+        -> bool
+    {
+        return true;
+    }
+
+    template<typename Iterator>
+    auto operator()(Iterator, Iterator) const
+        -> bool
+    {
+        return false;
+    }
+};
+
+struct non_comparison_sorter:
+    cppsort::sorter_base<non_comparison_sorter>
+{
+    using cppsort::sorter_base<non_comparison_sorter>::operator();
+
+    template<typename Iterator>
+    auto operator()(Iterator, Iterator)
+        -> bool
+    {
+        return true;
+    }
+};
+
+TEST_CASE( "std::less<> forwarding to sorters",
+           "[sorter_base][compare]" )
+{
+    // Check that hybrid_adapter takes into account
+    // the SFINAE in the aggregated sorters
+
+    // Vector to "sort"
+    std::vector<int> vec(3);
+
+    SECTION( "with std::less<>" )
+    {
+        CHECK( cppsort::sort(vec, comparison_sorter{}, std::less<>{}) );
+        CHECK( cppsort::sort(std::begin(vec), std::end(vec), comparison_sorter{}, std::less<>{}) );
+
+        CHECK( cppsort::sort(vec, non_comparison_sorter{}, std::less<>{}) );
+        CHECK( cppsort::sort(std::begin(vec), std::end(vec), non_comparison_sorter{}, std::less<>{}) );
+    }
+
+    SECTION( "with std::less<T>" )
+    {
+        CHECK( cppsort::sort(vec, comparison_sorter{}, std::less<int>{}) );
+        CHECK( cppsort::sort(std::begin(vec), std::end(vec), comparison_sorter{}, std::less<int>{}) );
+
+        CHECK( cppsort::sort(vec, non_comparison_sorter{}, std::less<int>{}) );
+        CHECK( cppsort::sort(std::begin(vec), std::end(vec), non_comparison_sorter{}, std::less<int>{}) );
+    }
+}

--- a/testsuite/sorter_base_std_less.cpp
+++ b/testsuite/sorter_base_std_less.cpp
@@ -21,14 +21,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <cassert>
+#include <functional>
 #include <iterator>
-#include <string>
-#include <type_traits>
 #include <vector>
 #include <catch.hpp>
+#include <cpp-sort/adapters/hybrid_adapter.h>
 #include <cpp-sort/sort.h>
 #include <cpp-sort/sorter_base.h>
+#include <cpp-sort/sorter_traits.h>
 
 struct comparison_sorter:
     cppsort::sorter_base<comparison_sorter>
@@ -66,8 +66,9 @@ struct non_comparison_sorter:
 TEST_CASE( "std::less<> forwarding to sorters",
            "[sorter_base][compare]" )
 {
-    // Check that hybrid_adapter takes into account
-    // the SFINAE in the aggregated sorters
+    // Check that sorter_base only creates the overloads for
+    // std::less when the original sorter does not support
+    // custom comparison functions
 
     // Vector to "sort"
     std::vector<int> vec(3);

--- a/testsuite/sorters/default_sorter.cpp
+++ b/testsuite/sorters/default_sorter.cpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <iterator>
 #include <list>
+#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sorters/default_sorter.h>

--- a/testsuite/sorters/default_sorter_fptr.cpp
+++ b/testsuite/sorters/default_sorter_fptr.cpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <iterator>
 #include <list>
+#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sorters/default_sorter.h>

--- a/testsuite/sorters/spread_sorter.cpp
+++ b/testsuite/sorters/spread_sorter.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <ctime>
 #include <iterator>
+#include <random>
 #include <string>
 #include <vector>
 #include <catch.hpp>


### PR DESCRIPTION
This branch adds the notion of partial comparison sorters to the library and updates the testsuite and the documentation accordingly. Until there, a sorter could either be a full comparison sorter and take any comparison function to sort its collection, or be a strict non-comparison sorter, taking no comparison function at all, and always sort the collection in ascending order.

This update allows to overload a sorter's `operator()` for specific comparison functions and defines a set of rules to make sure that everything goes smoothly when they are enforced (even though the library itself does not enforce them). `sorter_base` has also been updated so that any sorter can be called with `std::less` or `std::less<T>` to sort a collection in ascending order, regardless of whether the original sorter provides or not a way to be called with a comparison function.