### PR TITLE
Make quick_sorter work with forward iterators

### DIFF
--- a/doc/sorters.md
+++ b/doc/sorters.md
@@ -39,7 +39,10 @@ using default_sorter = self_sort_adapter<
     small_array_adapter<
         hybrid_adapter<
             inplace_merge_sorter,
-            insertion_sorter,
+            rebind_iterator_category<
+                quick_sorter,
+                std::bidirectional_iterator_tag
+            >,
             pdq_sorter
         >,
         std::make_index_sequence<10u>
@@ -78,7 +81,7 @@ Implements an in-place merge sort.
 Implements an [insertion sort](https://en.wikipedia.org/wiki/Insertion_sort).
 
     Best        Average     Worst       Memory      Stable      Iterators
-    n           n²          n²          1           Yes         Bidirectional
+    n           n²          n²          1           Yes         Forward
 
 ### `merge_sorter`
 
@@ -113,7 +116,7 @@ Implements a [quicksort](https://en.wikipedia.org/wiki/Quicksort).
 
 
     Best        Average     Worst       Memory      Stable      Iterators
-    n long n    n log n     n²          n           No          Bidirectional
+    n long n    n log n     n²          n           No          Forward
 
 ### `std_sorter`
 

--- a/include/cpp-sort/detail/bubble_sort.h
+++ b/include/cpp-sort/detail/bubble_sort.h
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_DETAIL_BUBBLE_SORT_H_
+#define CPPSORT_DETAIL_BUBBLE_SORT_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+
+namespace cppsort
+{
+namespace detail
+{
+    //
+    // This sorting algorithm isn't exposed to users of the
+    // library, it's only intended to be used as a fallback
+    // by other algorithms to sort small collections
+    //
+    // These recursive algorithms tend to compute the size
+    // of the collection, so bubble_sort can use it to have
+    // a decreasing bound for forward iterators
+    //
+
+    template<typename ForwardIterator, typename Compare>
+    void bubble_sort(ForwardIterator first, Compare compare, std::size_t size)
+    {
+        if (size < 2) return;
+
+        while (--size)
+        {
+            ForwardIterator current = first;
+            ForwardIterator next = std::next(current);
+            for (std::size_t i = 0 ; i < size ; ++i)
+            {
+                if (compare(*next, *current))
+                {
+                    std::iter_swap(current, next);
+                }
+                ++next;
+                ++current;
+            }
+        }
+    }
+}}
+
+#endif // CPPSORT_DETAIL_BUBBLE_SORT_H_

--- a/include/cpp-sort/detail/insertion_sort.h
+++ b/include/cpp-sort/detail/insertion_sort.h
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <functional>
+#include <algorithm>
 #include <iterator>
 #include <utility>
 
@@ -33,24 +33,21 @@ namespace cppsort
 {
 namespace detail
 {
-    // Sorts [first, last) using insertion sort with the given comparison function.
-    template<
-        typename BidirectionalIterator,
-        typename Compare = std::less<>
-    >
+    template<typename BidirectionalIterator, typename Compare>
     void insertion_sort(BidirectionalIterator first,
                         BidirectionalIterator last,
-                        Compare compare={})
+                        Compare compare,
+                        std::bidirectional_iterator_tag)
     {
         if (first == last)
         {
             return;
         }
 
-        for (auto cur = std::next(first) ; cur != last ; ++cur)
+        for (BidirectionalIterator cur = std::next(first) ; cur != last ; ++cur)
         {
-            auto sift = cur;
-            auto sift_1 = std::prev(cur);
+            BidirectionalIterator sift = cur;
+            BidirectionalIterator sift_1 = std::prev(cur);
 
             // Compare first so we can avoid 2 moves for
             // an element already positioned correctly.
@@ -65,6 +62,25 @@ namespace detail
                 *sift = std::move(tmp);
             }
         }
+    }
+
+    template<typename ForwardIterator, typename Compare>
+    void insertion_sort(ForwardIterator first, ForwardIterator last,
+                        Compare compare,
+                        std::forward_iterator_tag)
+    {
+        for (ForwardIterator it = first ; it != last ; ++it) {
+            ForwardIterator insertion_point = std::upper_bound(first, it, *it, compare);
+            std::rotate(insertion_point, it, std::next(it));
+        }
+    }
+
+    template<typename ForwardIterator, typename Compare>
+    void insertion_sort(ForwardIterator first, ForwardIterator last,
+                        Compare compare)
+    {
+        using category = typename std::iterator_traits<ForwardIterator>::iterator_category;
+        insertion_sort(first, last, compare, category{});
     }
 }}
 

--- a/include/cpp-sort/detail/iter_sort3.h
+++ b/include/cpp-sort/detail/iter_sort3.h
@@ -1,0 +1,56 @@
+/*
+    pdqsort.h - Pattern-defeating quicksort.
+
+    Copyright (c) 2015 Orson Peters
+    Modified in 2015 by Morwenn for inclusion into cpp-sort
+
+    This software is provided 'as-is', without any express or implied warranty. In no event will the
+    authors be held liable for any damages arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose, including commercial
+    applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not claim that you wrote the
+       original software. If you use this software in a product, an acknowledgment in the product
+       documentation would be appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+       being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+#ifndef CPPSORT_DETAIL_ITER_SORT3_H_
+#define CPPSORT_DETAIL_ITER_SORT3_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <algorithm>
+
+namespace cppsort
+{
+namespace detail
+{
+    // Sorts the elements *a, *b and *c using comparison function comp.
+    template<class Iter, class Compare>
+    void iter_sort3(Iter a, Iter b, Iter c, Compare comp) {
+        if (!comp(*b, *a)) {
+            if (!comp(*c, *b)) return;
+
+            std::iter_swap(b, c);
+            if (comp(*b, *a)) std::iter_swap(a, b);
+
+            return;
+        }
+
+        if (comp(*c, *b)) {
+            std::iter_swap(a, c);
+            return;
+        }
+
+        std::iter_swap(a, b);
+        if (comp(*c, *b)) std::iter_swap(b, c);
+    }
+}}
+
+#endif // CPPSORT_DETAIL_ITER_SORT3_H_

--- a/include/cpp-sort/detail/pdqsort.h
+++ b/include/cpp-sort/detail/pdqsort.h
@@ -22,11 +22,15 @@
 #ifndef CPPSORT_DETAIL_PDQSORT_H_
 #define CPPSORT_DETAIL_PDQSORT_H_
 
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
 #include <algorithm>
 #include <functional>
 #include <utility>
 #include <cpp-sort/utility/log2.h>
 #include "insertion_sort.h"
+#include "iter_sort3.h"
 
 namespace cppsort
 {
@@ -126,27 +130,6 @@ namespace detail
             return true;
         }
 
-        // Sorts the elements *a, *b and *c using comparison function comp.
-        template<class Iter, class Compare>
-        void sort3(Iter a, Iter b, Iter c, Compare comp) {
-            if (!comp(*b, *a)) {
-                if (!comp(*c, *b)) return;
-
-                std::iter_swap(b, c);
-                if (comp(*b, *a)) std::iter_swap(a, b);
-
-                return;
-            }
-
-            if (comp(*c, *b)) {
-                std::iter_swap(a, c);
-                return;
-            }
-
-            std::iter_swap(a, b);
-            if (comp(*c, *b)) std::iter_swap(b, c);
-        }
-
         // Partitions [begin, end) around pivot *begin using comparison function comp. Elements equal
         // to the pivot are put in the right-hand partition. Returns the position of the pivot after
         // partitioning and whether the passed sequence already was correctly partitioned. Assumes the
@@ -237,7 +220,7 @@ namespace detail
                 }
 
                 // Choose pivot as median of 3.
-                sort3(begin + size / 2, begin, end - 1, comp);
+                iter_sort3(begin + size / 2, begin, end - 1, comp);
 
                 // If *(begin - 1) is the end of the right partition of a previous partition operation
                 // there is no element in [*begin, end) that is smaller than *(begin - 1). Then if our

--- a/include/cpp-sort/detail/quicksort.h
+++ b/include/cpp-sort/detail/quicksort.h
@@ -24,11 +24,15 @@
 #ifndef CPPSORT_DETAIL_QUICKSORT_H_
 #define CPPSORT_DETAIL_QUICKSORT_H_
 
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
+#include "bubble_sort.h"
 #include "insertion_sort.h"
-#include "selection_sort.h"
+#include "iter_sort3.h"
 
 namespace cppsort
 {
@@ -40,15 +44,19 @@ namespace detail
                    std::forward_iterator_tag category)
     {
         // If the collection is small, fall back to
-        // insertion sort
-        if (size < 15)
+        // bubble sort
+        if (size < 10)
         {
-            selection_sort(first, last, compare);
+            bubble_sort(first, compare, size);
             return;
         }
 
-        // Choose a pivot, size / 2 is ok
-        const auto& pivot = *std::next(first, size / 2);
+        // Choose pivot as median of 3
+        ForwardIterator middle = std::next(first, size / 2);
+        iter_sort3(first, middle,
+                   std::next(middle, size - size/2 - 1),
+                   compare);
+        const auto& pivot = *middle;
 
         // Partition the collection
         ForwardIterator middle1 = std::partition(
@@ -77,14 +85,16 @@ namespace detail
     {
         // If the collection is small, fall back to
         // insertion sort
-        if (size < 45)
+        if (size < 42)
         {
             insertion_sort(first, last, compare);
             return;
         }
 
-        // Choose a pivot, size / 2 is ok
-        const auto& pivot = *std::next(first, size / 2);
+        // Choose pivot as median of 3
+        BidirectionalIterator middle = std::next(first, size / 2);
+        iter_sort3(first, middle, std::prev(last), compare);
+        const auto& pivot = *middle;
 
         // Partition the collection
         BidirectionalIterator middle1 = std::partition(

--- a/include/cpp-sort/detail/quicksort.h
+++ b/include/cpp-sort/detail/quicksort.h
@@ -33,8 +33,8 @@ namespace cppsort
 {
 namespace detail
 {
-    template <typename BidirectionalIterator, typename Compare>
-    void quicksort(BidirectionalIterator first, BidirectionalIterator last,
+    template <typename ForwardIterator, typename Compare>
+    void quicksort(ForwardIterator first, ForwardIterator last,
                    Compare compare, std::size_t size)
     {
         // If the collection is small, fall back to
@@ -49,11 +49,11 @@ namespace detail
         const auto& pivot = *std::next(first, size / 2);
 
         // Partition the collection
-        BidirectionalIterator middle1 = std::partition(
+        ForwardIterator middle1 = std::partition(
             first, last,
             [=](const auto& elem) { return compare(elem, pivot); }
         );
-        BidirectionalIterator middle2 = std::partition(
+        ForwardIterator middle2 = std::partition(
             middle1, last,
             [=](const auto& elem) { return not compare(pivot, elem); }
         );

--- a/include/cpp-sort/sorters/default_sorter.h
+++ b/include/cpp-sort/sorters/default_sorter.h
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <iterator>
 #include <utility>
 #include <cpp-sort/adapters/hybrid_adapter.h>
 #include <cpp-sort/adapters/self_sort_adapter.h>
@@ -34,6 +35,7 @@
 #include <cpp-sort/sorters/inplace_merge_sorter.h>
 #include <cpp-sort/sorters/pdq_sorter.h>
 #include <cpp-sort/sorters/quick_sorter.h>
+#include <cpp-sort/sorter_traits.h>
 
 namespace cppsort
 {
@@ -41,7 +43,10 @@ namespace cppsort
         small_array_adapter<
             hybrid_adapter<
                 inplace_merge_sorter,
-                quick_sorter,
+                rebind_iterator_category<
+                    quick_sorter,
+                    std::bidirectional_iterator_tag
+                >,
                 pdq_sorter
             >,
             std::make_index_sequence<10u>

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -44,11 +44,10 @@ namespace cppsort
         using sorter_base<insertion_sorter>::operator();
 
         template<
-            typename BidirectionalIterator,
+            typename ForwardIterator,
             typename Compare = std::less<>
         >
-        auto operator()(BidirectionalIterator first,
-                        BidirectionalIterator last,
+        auto operator()(ForwardIterator first, ForwardIterator last,
                         Compare compare={}) const
             -> void
         {
@@ -62,7 +61,7 @@ namespace cppsort
     template<>
     struct sorter_traits<insertion_sorter>
     {
-        using iterator_category = std::bidirectional_iterator_tag;
+        using iterator_category = std::forward_iterator_tag;
         static constexpr bool is_stable = true;
     };
 }

--- a/include/cpp-sort/sorters/quick_sorter.h
+++ b/include/cpp-sort/sorters/quick_sorter.h
@@ -43,10 +43,10 @@ namespace cppsort
         sorter_base<quick_sorter>
     {
         template<
-            typename BidirectionalIterable,
+            typename ForwardIterable,
             typename Compare = std::less<>
         >
-        auto operator()(BidirectionalIterable& iterable, Compare compare={}) const
+        auto operator()(ForwardIterable& iterable, Compare compare={}) const
             -> void
         {
             detail::quicksort(
@@ -58,11 +58,10 @@ namespace cppsort
         }
 
         template<
-            typename BidirectionalIterator,
+            typename ForwardIterator,
             typename Compare = std::less<>
         >
-        auto operator()(BidirectionalIterator first,
-                        BidirectionalIterator last,
+        auto operator()(ForwardIterator first, ForwardIterator last,
                         Compare compare={}) const
             -> void
         {
@@ -80,7 +79,7 @@ namespace cppsort
     template<>
     struct sorter_traits<quick_sorter>
     {
-        using iterator_category = std::bidirectional_iterator_tag;
+        using iterator_category = std::forward_iterator_tag;
         static constexpr bool is_stable = false;
     };
 }


### PR DESCRIPTION
This branch makes `quick_sorter` work with forward iterators instead of simply bidirectional iterators. It also updates the quicksort implementation to use a deterministic median-of-3 pivot to reduce the chances of quadratic behaviour. The following changes have also been made because they are or were needed at some point:
* `insertion_sorter` works with forward iterators too (even though it isn't really efficient).
* A special bubble sort implementation has been added for fallbacks.
* `sort3` has been factored out of pdqsort.h and renamed `iter_sort3`.
* Quicksort and insertion sort both use tag dispatch to switch to use a more efficient implementation depending on the iterator category of the collection to sort.
* `default_sorter` rebinds `quick_sorter`'s iterator category to `std::bidirectional_iterator_tag` to remain consistent with its old behaviour.

Of course, the documentation has been updated to reflect the changes in the library's interface.