### PR TITLE
Nuke std::less<T> overloads in sorter_facade.

### DIFF
--- a/include/cpp-sort/sorter_facade.h
+++ b/include/cpp-sort/sorter_facade.h
@@ -193,37 +193,6 @@ namespace cppsort
             }
 
             ////////////////////////////////////////////////////////////
-            // std::less<T> overloads
-
-            template<typename Iterator>
-            auto operator()(Iterator first, Iterator last,
-                            std::less<typename std::iterator_traits<Iterator>::value_type>) const
-                -> std::enable_if_t<
-                    not detail::has_comparison_sort_iterator<
-                    Sorter, Iterator,
-                    std::less<typename std::iterator_traits<Iterator>::value_type>>,
-                    decltype(Sorter::operator()(first, last))
-                >
-            {
-                return Sorter::operator()(first, last);
-            }
-
-            template<typename Iterable>
-            auto operator()(Iterable& iterable,
-                            std::less<typename std::iterator_traits<decltype(std::begin(iterable))>::value_type>) const
-                -> std::enable_if_t<
-                    not detail::has_comparison_sort_iterator<
-                        Sorter,
-                        decltype(std::begin(iterable)),
-                        std::less<typename std::iterator_traits<decltype(std::begin(iterable))>::value_type>
-                    >,
-                    decltype(operator()(iterable))
-                >
-            {
-                return operator()(iterable);
-            }
-
-            ////////////////////////////////////////////////////////////
             // Projection overloads
 
             template<typename Iterator, typename Projection>

--- a/testsuite/sorter_facade_std_less.cpp
+++ b/testsuite/sorter_facade_std_less.cpp
@@ -114,16 +114,4 @@ TEST_CASE( "std::less<> forwarding to sorters",
         CHECK( not cppsort::sort(vec, non_comparison_iterable_sorter{}, std::less<>{}) );
         CHECK( cppsort::sort(std::begin(vec), std::end(vec), non_comparison_iterable_sorter{}, std::less<>{}) );
     }
-
-    SECTION( "with std::less<T>" )
-    {
-        CHECK( cppsort::sort(vec, comparison_sorter{}, std::less<int>{}) );
-        CHECK( cppsort::sort(std::begin(vec), std::end(vec), comparison_sorter{}, std::less<int>{}) );
-
-        CHECK( cppsort::sort(vec, non_comparison_sorter{}, std::less<int>{}) );
-        CHECK( cppsort::sort(std::begin(vec), std::end(vec), non_comparison_sorter{}, std::less<int>{}) );
-
-        CHECK( not cppsort::sort(vec, non_comparison_iterable_sorter{}, std::less<int>{}) );
-        CHECK( cppsort::sort(std::begin(vec), std::end(vec), non_comparison_iterable_sorter{}, std::less<int>{}) );
-    }
 }

--- a/testsuite/sorters/spread_sorter_defaults.cpp
+++ b/testsuite/sorters/spread_sorter_defaults.cpp
@@ -55,18 +55,4 @@ TEST_CASE( "spread_sorter generate overloads",
         cppsort::sort(std::begin(vec), std::end(vec), cppsort::spread_sorter{}, std::less<>{});
         CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::less<>{}) );
     }
-
-    SECTION( "default operator() with std::less<int>" )
-    {
-        std::vector<int> vec(100'000);
-        std::iota(std::begin(vec), std::end(vec), 0u);
-
-        std::shuffle(std::begin(vec), std::end(vec), engine);
-        cppsort::sort(vec, cppsort::spread_sorter{}, std::less<int>{});
-        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::less<int>{}) );
-
-        std::shuffle(std::begin(vec), std::end(vec), engine);
-        cppsort::sort(std::begin(vec), std::end(vec), cppsort::spread_sorter{}, std::less<int>{});
-        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::less<int>{}) );
-    }
 }


### PR DESCRIPTION
Remove default support for `std::less<T>` from `sorter_facade` and the associated tests. The library was never meant to be legacy-friendly anyway and it introduced some inconsistencies as well as making tests fail with Clang and increasing the maintainance cost. We call live without them and use `std::less<>` everywhere instead.