### PR TITLE
Tentative Valgrind support in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     packages:
       - clang-3.8
       - g++-5
+      - valgrind
 
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5"; fi
@@ -24,7 +25,7 @@ install:
 script: 
   - cmake .
   - make
-  - testsuite/cpp-sort-testsuite
+  - valgrind --leak-check=full testsuite/cpp-sort-testsuite
 
 notifications:
   email: false


### PR DESCRIPTION
Add full leak check for the testsuite with Valgrind in .travis.yml. Apparently, there isn't a single memory error as of right now, so... nothing more to do.