### PR TITLE
Embed traits into sorters and adapters. Fixes #10.

### DIFF
--- a/examples/bubble_sorter.cpp
+++ b/examples/bubble_sorter.cpp
@@ -27,7 +27,6 @@
 #include <iterator>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
-#include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/functional.h>
 #include <cpp-sort/utility/size.h>
@@ -116,22 +115,16 @@ namespace detail
                         compare, projection,
                         cppsort::utility::size(iterable));
         }
+
+        // Sorter traits
+        using iterator_category = std::forward_iterator_tag;
+        using is_stable = std::true_type;
     };
 }
 
 struct bubble_sorter:
     cppsort::sorter_facade<detail::bubble_sorter_impl>
 {};
-
-namespace cppsort
-{
-    template<>
-    struct sorter_traits<::bubble_sorter>
-    {
-        using iterator_category = std::forward_iterator_tag;
-        using is_stable = std::true_type;
-    };
-}
 
 #include <array>
 #include <cassert>

--- a/include/cpp-sort/adapters/counting_adapter.h
+++ b/include/cpp-sort/adapters/counting_adapter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@
 #include <utility>
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
+#include "../detail/checkers.h"
 #include "../detail/comparison_counter.h"
 
 namespace cppsort
@@ -43,7 +44,9 @@ namespace cppsort
     namespace detail
     {
         template<typename ComparisonSorter, typename CountType>
-        struct counting_adapter_impl
+        struct counting_adapter_impl:
+            check_iterator_category<ComparisonSorter>,
+            check_is_stable<ComparisonSorter>
         {
             template<
                 typename Iterable,
@@ -121,16 +124,6 @@ namespace cppsort
             CountType
         >>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<typename ComparisonSorter, typename CountType>
-    struct sorter_traits<counting_adapter<ComparisonSorter, CountType>>
-    {
-        using iterator_category = cppsort::iterator_category<ComparisonSorter>;
-        using is_stable = cppsort::is_stable<ComparisonSorter>;
-    };
 }
 
 #endif // CPPSORT_ADAPTERS_COUNTING_ADAPTER_H_

--- a/include/cpp-sort/adapters/hybrid_adapter.h
+++ b/include/cpp-sort/adapters/hybrid_adapter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/any_all.h>
+#include "../detail/checkers.h"
 
 namespace cppsort
 {
@@ -77,7 +78,9 @@ namespace cppsort
         // Adapter
 
         template<typename... Sorters>
-        class hybrid_adapter_impl
+        class hybrid_adapter_impl:
+            public check_iterator_category<Sorters...>,
+            public check_is_stable<Sorters...>
         {
             private:
 
@@ -195,24 +198,6 @@ namespace cppsort
     struct hybrid_adapter:
         sorter_facade<detail::hybrid_adapter_impl<Sorters...>>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<typename... Sorters>
-    struct sorter_traits<hybrid_adapter<Sorters...>>
-    {
-        // The iterator category is the least constrained one
-        // among the aggregated sorters
-        using iterator_category = std::common_type_t<cppsort::iterator_category<Sorters>...>;
-
-        // The adapter is stable only if every aggregated sorter
-        // is stable
-        using is_stable = std::integral_constant<
-            bool,
-            utility::all(cppsort::is_stable<Sorters>::value...)
-        >;
-    };
 }
 
 #endif // CPPSORT_ADAPTERS_HYBRID_ADAPTER_H_

--- a/include/cpp-sort/adapters/indirect_adapter.h
+++ b/include/cpp-sort/adapters/indirect_adapter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include "../detail/checkers.h"
 #include "../detail/indirect_compare.h"
 
 namespace cppsort
@@ -44,7 +45,8 @@ namespace cppsort
     namespace detail
     {
         template<typename Sorter>
-        struct indirect_adapter_impl
+        struct indirect_adapter_impl:
+            check_is_stable<Sorter>
         {
             template<
                 typename RandomAccessIterator,
@@ -110,6 +112,11 @@ namespace cppsort
                     while (start != last && sorted[start - first]);
                 }
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
         };
     }
 
@@ -117,16 +124,6 @@ namespace cppsort
     struct indirect_adapter:
         sorter_facade<detail::indirect_adapter_impl<Sorter>>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<typename Sorter>
-    struct sorter_traits<indirect_adapter<Sorter>>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = cppsort::is_stable<Sorter>;
-    };
 }
 
 #endif // CPPSORT_ADAPTERS_INDIRECT_ADAPTER_H_

--- a/include/cpp-sort/adapters/self_sort_adapter.h
+++ b/include/cpp-sort/adapters/self_sort_adapter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,8 +30,8 @@
 #include <type_traits>
 #include <utility>
 #include <cpp-sort/sorter_facade.h>
-#include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/has_sort_method.h>
+#include "../detail/checkers.h"
 
 namespace cppsort
 {
@@ -41,7 +41,8 @@ namespace cppsort
     namespace detail
     {
         template<typename Sorter>
-        struct self_sort_adapter_impl
+        struct self_sort_adapter_impl:
+            check_iterator_category<Sorter>
         {
             template<
                 typename Iterable,
@@ -72,6 +73,13 @@ namespace cppsort
             {
                 return Sorter{}(first, last, std::forward<Args>(args)...);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            // We can't guarantee the stability of the sort method,
+            // therefore we default the stability to false
+            using is_stable = std::false_type;
         };
     }
 
@@ -79,19 +87,6 @@ namespace cppsort
     struct self_sort_adapter:
         sorter_facade<detail::self_sort_adapter_impl<Sorter>>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<typename Sorter>
-    struct sorter_traits<self_sort_adapter<Sorter>>
-    {
-        using iterator_category = cppsort::iterator_category<Sorter>;
-
-        // We can't guarantee the stability of the sort method,
-        // therefore we default the stability to false
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_ADAPTERS_SELF_SORT_ADAPTER_H_

--- a/include/cpp-sort/adapters/small_array_adapter.h
+++ b/include/cpp-sort/adapters/small_array_adapter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +33,6 @@
 #include <type_traits>
 #include <utility>
 #include <cpp-sort/sorter_facade.h>
-#include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/is_in_pack.h>
 
 namespace cppsort
@@ -80,6 +79,15 @@ namespace cppsort
             {
                 return Sorter<N>{}(array, args...);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            // Without more evolved tools, we can't assume much about
+            // fixed-size sorters in general, so we default these values
+            // to the most restrictive ones
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::false_type;
         };
 
         template<template<std::size_t> class Sorter>
@@ -106,6 +114,15 @@ namespace cppsort
             {
                 return Sorter<N>{}(array, args...);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            // Without more evolved tools, we can't assume much about
+            // fixed-size sorters in general, so we default these values
+            // to the most restrictive ones
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
@@ -116,24 +133,6 @@ namespace cppsort
     struct small_array_adapter:
         sorter_facade<detail::small_array_adapter_impl<Sorter, Indices>>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<
-        template<std::size_t> class Sorter,
-        typename Indices
-    >
-    struct sorter_traits<small_array_adapter<Sorter, Indices>>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-
-        // Some of the algorithms are stable, some other are not,
-        // the stability *could* be documented depending on which
-        // fixed-size algorithms are used, but it would be lots of
-        // work...
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_ADAPTERS_SMALL_ARRAY_ADAPTER_H_

--- a/include/cpp-sort/detail/checkers.h
+++ b/include/cpp-sort/detail/checkers.h
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_DETAIL_CHECKERS_H_
+#define CPPSORT_DETAIL_CHECKERS_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <type_traits>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/any_all.h>
+#include <cpp-sort/utility/detection.h>
+#include "raw_checkers.h"
+
+namespace cppsort
+{
+namespace detail
+{
+    ////////////////////////////////////////////////////////////
+    // High-level checkers (check with sorter_traits)
+
+    template<bool, typename...>
+    struct check_iterator_category_impl {};
+
+    template<typename... Sorters>
+    struct check_iterator_category_impl<true, Sorters...>
+    {
+        using iterator_category = std::common_type_t<
+            typename sorter_traits<Sorters>::iterator_category...
+        >;
+    };
+
+    template<typename... Sorters>
+    struct check_iterator_category:
+        check_iterator_category_impl<
+            utility::all(has_iterator_category<sorter_traits<Sorters>>::value...),
+            Sorters...
+        >
+    {};
+
+    template<bool, typename...>
+    struct check_is_stable_impl {};
+
+    template<typename... Sorters>
+    struct check_is_stable_impl<true, Sorters...>
+    {
+        using is_stable = std::integral_constant<
+            bool,
+            utility::all(typename sorter_traits<Sorters>::is_stable{}()...)
+        >;
+    };
+
+    template<typename... Sorters>
+    struct check_is_stable:
+        check_is_stable_impl<
+            utility::all(has_is_stable<sorter_traits<Sorters>>::value...),
+            Sorters...
+        >
+    {};
+}}
+
+#endif // CPPSORT_DETAIL_CHECKERS_H_

--- a/include/cpp-sort/detail/raw_checkers.h
+++ b/include/cpp-sort/detail/raw_checkers.h
@@ -1,0 +1,101 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_DETAIL_RAW_CHECKERS_H_
+#define CPPSORT_DETAIL_RAW_CHECKERS_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <type_traits>
+#include <cpp-sort/utility/any_all.h>
+#include <cpp-sort/utility/detection.h>
+
+namespace cppsort
+{
+namespace detail
+{
+    ////////////////////////////////////////////////////////////
+    // Raw checkers (check with the type itself)
+
+    template<typename T, typename=void>
+    struct has_iterator_category:
+        std::false_type
+    {};
+
+    template<typename T>
+    struct has_iterator_category<T, utility::void_t<typename T::iterator_category>>:
+        std::true_type
+    {};
+
+    template<bool, typename...>
+    struct raw_check_iterator_category_impl {};
+
+    template<typename... Sorters>
+    struct raw_check_iterator_category_impl<true, Sorters...>
+    {
+        using iterator_category = std::common_type_t<
+            typename Sorters::iterator_category...
+        >;
+    };
+
+    template<typename... Sorters>
+    struct raw_check_iterator_category:
+        raw_check_iterator_category_impl<
+            utility::all(has_iterator_category<Sorters>::value...),
+            Sorters...
+        >
+    {};
+
+    template<typename T, typename=void>
+    struct has_is_stable:
+        std::false_type
+    {};
+
+    template<typename T>
+    struct has_is_stable<T, utility::void_t<typename T::is_stable>>:
+        std::true_type
+    {};
+
+    template<bool, typename...>
+    struct raw_check_is_stable_impl {};
+
+    template<typename... Sorters>
+    struct raw_check_is_stable_impl<true, Sorters...>
+    {
+        using is_stable = std::integral_constant<
+            bool,
+            utility::all(typename Sorters::is_stable{}()...)
+        >;
+    };
+
+    template<typename... Sorters>
+    struct raw_check_is_stable:
+        raw_check_is_stable_impl<
+            utility::all(has_is_stable<Sorters>::value...),
+            Sorters...
+        >
+    {};
+}}
+
+#endif // CPPSORT_DETAIL_RAW_CHECKERS_H_

--- a/include/cpp-sort/sorter_traits.h
+++ b/include/cpp-sort/sorter_traits.h
@@ -255,18 +255,14 @@ namespace cppsort
     {
         static_assert(
             std::is_base_of<
-                iterator_category<Sorter>,
+                cppsort::iterator_category<Sorter>,
                 Category
             >::value,
             "the new iterator category should be more specific"
         );
-    };
 
-    template<typename Sorter, typename Category>
-    struct sorter_traits<rebind_iterator_category<Sorter, Category>>
-    {
+        // New category
         using iterator_category = Category;
-        using is_stable = cppsort::is_stable<Sorter>;
     };
 }
 

--- a/include/cpp-sort/sorter_traits.h
+++ b/include/cpp-sort/sorter_traits.h
@@ -228,11 +228,37 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter traits
 
-    template<typename Sorter>
-    struct sorter_traits
+    namespace detail
     {
-        // Defined but empty for SFINAE friendliness
-    };
+        // This trait class is a bit different than usual traits
+        // classes: the goal is to decrease the coupling between
+        // the different traits and to make programs using one of
+        // the traits valid even if the other traits don't exist
+
+        template<typename T, typename=void>
+        struct check_iterator_category {};
+
+        template<typename T>
+        struct check_iterator_category<T, utility::void_t<typename T::iterator_category>>
+        {
+            using iterator_category = typename T::iterator_category;
+        };
+
+        template<typename T, typename=void>
+        struct check_is_stable {};
+
+        template<typename T>
+        struct check_is_stable<T, utility::void_t<typename T::is_stable>>
+        {
+            using is_stable = typename T::is_stable;
+        };
+    }
+
+    template<typename Sorter>
+    struct sorter_traits:
+        detail::check_iterator_category<Sorter>,
+        detail::check_is_stable<Sorter>
+    {};
 
     template<typename Sorter>
     using iterator_category = typename sorter_traits<Sorter>::iterator_category;

--- a/include/cpp-sort/sorter_traits.h
+++ b/include/cpp-sort/sorter_traits.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/detection.h>
 #include <cpp-sort/utility/functional.h>
+#include "detail/raw_checkers.h"
 
 namespace cppsort
 {
@@ -228,36 +229,15 @@ namespace cppsort
     ////////////////////////////////////////////////////////////
     // Sorter traits
 
-    namespace detail
-    {
-        // This trait class is a bit different than usual traits
-        // classes: the goal is to decrease the coupling between
-        // the different traits and to make programs using one of
-        // the traits valid even if the other traits don't exist
-
-        template<typename T, typename=void>
-        struct check_iterator_category {};
-
-        template<typename T>
-        struct check_iterator_category<T, utility::void_t<typename T::iterator_category>>
-        {
-            using iterator_category = typename T::iterator_category;
-        };
-
-        template<typename T, typename=void>
-        struct check_is_stable {};
-
-        template<typename T>
-        struct check_is_stable<T, utility::void_t<typename T::is_stable>>
-        {
-            using is_stable = typename T::is_stable;
-        };
-    }
+    // This trait class is a bit different than usual traits
+    // classes: the goal is to decrease the coupling between
+    // the different traits and to make programs using one of
+    // the traits valid even if the other traits don't exist
 
     template<typename Sorter>
     struct sorter_traits:
-        detail::check_iterator_category<Sorter>,
-        detail::check_is_stable<Sorter>
+        detail::raw_check_iterator_category<Sorter>,
+        detail::raw_check_is_stable<Sorter>
     {};
 
     template<typename Sorter>

--- a/include/cpp-sort/sorters/block_sorter.h
+++ b/include/cpp-sort/sorters/block_sorter.h
@@ -68,6 +68,12 @@ namespace cppsort
 
                 block_sort<BufferProvider>(first, last, compare, projection);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::true_type;
         };
     }
 
@@ -77,16 +83,6 @@ namespace cppsort
     struct block_sorter:
         sorter_facade<detail::block_sorter_impl<BufferProvider>>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<typename BufferProvider>
-    struct sorter_traits<block_sorter<BufferProvider>>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::true_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_BLOCK_SORTER_H_

--- a/include/cpp-sort/sorters/grail_sorter.h
+++ b/include/cpp-sort/sorters/grail_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -68,6 +68,12 @@ namespace cppsort
 
                 grail_sort<BufferProvider>(first, last, compare, projection);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::true_type;
         };
     }
 
@@ -77,16 +83,6 @@ namespace cppsort
     struct grail_sorter:
         sorter_facade<detail::grail_sorter_impl<BufferProvider>>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<typename BufferProvider>
-    struct sorter_traits<grail_sorter<BufferProvider>>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::true_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_GRAIL_SORTER_H_

--- a/include/cpp-sort/sorters/heap_sorter.h
+++ b/include/cpp-sort/sorters/heap_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,22 +66,18 @@ namespace cppsort
 
                 heapsort(first, last, compare, projection);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
     struct heap_sorter:
         sorter_facade<detail::heap_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<heap_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_HEAP_SORTER_H_

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,22 +66,18 @@ namespace cppsort
 
                 insertion_sort(first, last, compare, projection);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::forward_iterator_tag;
+            using is_stable = std::true_type;
         };
     }
 
     struct insertion_sorter:
         sorter_facade<detail::insertion_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<insertion_sorter>
-    {
-        using iterator_category = std::forward_iterator_tag;
-        using is_stable = std::true_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_INSERTION_SORTER_H_

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -94,22 +94,18 @@ namespace cppsort
                            compare, projection,
                            std::distance(first, last));
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::forward_iterator_tag;
+            using is_stable = std::true_type;
         };
     }
 
     struct merge_sorter:
         sorter_facade<detail::merge_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<merge_sorter>
-    {
-        using iterator_category = std::forward_iterator_tag;
-        using is_stable = std::true_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_MERGE_SORTER_H_

--- a/include/cpp-sort/sorters/pdq_sorter.h
+++ b/include/cpp-sort/sorters/pdq_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,22 +66,18 @@ namespace cppsort
 
                 pdqsort(first, last, compare, projection);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
     struct pdq_sorter:
         sorter_facade<detail::pdq_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<pdq_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_PDQ_SORTER_H_

--- a/include/cpp-sort/sorters/quick_sorter.h
+++ b/include/cpp-sort/sorters/quick_sorter.h
@@ -94,22 +94,18 @@ namespace cppsort
                           compare, projection,
                           std::distance(first, last));
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::forward_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
     struct quick_sorter:
         sorter_facade<detail::quick_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<quick_sorter>
-    {
-        using iterator_category = std::forward_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_QUICK_SORTER_H_

--- a/include/cpp-sort/sorters/selection_sorter.h
+++ b/include/cpp-sort/sorters/selection_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,22 +66,18 @@ namespace cppsort
 
                 selection_sort(first, last, compare, projection);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::forward_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
     struct selection_sorter:
         sorter_facade<detail::selection_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<selection_sorter>
-    {
-        using iterator_category = std::forward_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_SELECTION_SORTER_H_

--- a/include/cpp-sort/sorters/smooth_sorter.h
+++ b/include/cpp-sort/sorters/smooth_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,22 +66,18 @@ namespace cppsort
 
                 smoothsort(first, last, compare, projection);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
     struct smooth_sorter:
         sorter_facade<detail::smooth_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<smooth_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_SMOOTH_SORTER_H_

--- a/include/cpp-sort/sorters/spread_sorter/float_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/float_spread_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,6 @@
 #include <limits>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
-#include <cpp-sort/sorter_traits.h>
 #include "../../detail/spreadsort/float_sort.h"
 
 namespace cppsort
@@ -53,22 +52,18 @@ namespace cppsort
             {
                 spreadsort::float_sort(first, last);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
     struct float_spread_sorter:
         sorter_facade<detail::float_spread_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<float_spread_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_SPREAD_SORTER_FLOAT_SPREAD_SORTER_H_

--- a/include/cpp-sort/sorters/spread_sorter/integer_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/integer_spread_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,6 @@
 #include <iterator>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
-#include <cpp-sort/sorter_traits.h>
 #include "../../detail/spreadsort/integer_sort.h"
 
 namespace cppsort
@@ -52,22 +51,18 @@ namespace cppsort
             {
                 spreadsort::integer_sort(first, last);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
     struct integer_spread_sorter:
         sorter_facade<detail::integer_spread_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<integer_spread_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_SPREAD_SORTER_INTEGER_SPREAD_SORTER_H_

--- a/include/cpp-sort/sorters/spread_sorter/string_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/string_spread_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@
 #include <string>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
-#include <cpp-sort/sorter_traits.h>
 #include "../../detail/spreadsort/string_sort.h"
 
 namespace cppsort
@@ -119,22 +118,18 @@ namespace cppsort
                 std::uint16_t unused = 0;
                 spreadsort::reverse_string_sort(first, last, compare, unused);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
     struct string_spread_sorter:
         sorter_facade<detail::string_spread_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<string_spread_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_SPREAD_SORTER_STRING_SPREAD_SORTER_H_

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@
 #include <iterator>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
-#include <cpp-sort/sorter_traits.h>
 
 namespace cppsort
 {
@@ -61,22 +60,18 @@ namespace cppsort
 
                 std::sort(first, last, compare);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
     struct std_sorter:
         sorter_facade<detail::std_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<std_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_STD_SORTER_H_

--- a/include/cpp-sort/sorters/std_stable_sorter.h
+++ b/include/cpp-sort/sorters/std_stable_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@
 #include <iterator>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
-#include <cpp-sort/sorter_traits.h>
 
 namespace cppsort
 {
@@ -61,22 +60,18 @@ namespace cppsort
 
                 std::stable_sort(first, last, compare);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::true_type;
         };
     }
 
     struct std_stable_sorter:
         sorter_facade<detail::std_stable_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<std_stable_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::true_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_STD_STABLE_SORTER_H_

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,22 +66,18 @@ namespace cppsort
 
                 timsort(first, last, compare, projection);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::true_type;
         };
     }
 
     struct tim_sorter:
         sorter_facade<detail::tim_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<tim_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::true_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_TIM_SORTER_H_

--- a/include/cpp-sort/sorters/verge_sorter.h
+++ b/include/cpp-sort/sorters/verge_sorter.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,22 +66,18 @@ namespace cppsort
 
                 vergesort(first, last, compare, projection);
             }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::bidirectional_iterator_tag;
+            using is_stable = std::false_type;
         };
     }
 
     struct verge_sorter:
         sorter_facade<detail::verge_sorter_impl>
     {};
-
-    ////////////////////////////////////////////////////////////
-    // Sorter traits
-
-    template<>
-    struct sorter_traits<verge_sorter>
-    {
-        using iterator_category = std::bidirectional_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 #endif // CPPSORT_SORTERS_VERGE_SORTER_H_

--- a/testsuite/adapters/hybrid_adapter_partial_compare.cpp
+++ b/testsuite/adapters/hybrid_adapter_partial_compare.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,6 +54,8 @@ namespace
         {
             return sorter_type::descending;
         }
+
+        using iterator_category = std::random_access_iterator_tag;
     };
 
     struct generic_sorter_impl
@@ -64,6 +66,8 @@ namespace
         {
             return sorter_type::generic;
         }
+
+        using iterator_category = std::forward_iterator_tag;
     };
 
     struct partial_comparison_sorter:
@@ -73,23 +77,6 @@ namespace
     struct generic_sorter:
         cppsort::sorter_facade<generic_sorter_impl>
     {};
-}
-
-namespace cppsort
-{
-    template<>
-    struct sorter_traits<partial_comparison_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
-
-    template<>
-    struct sorter_traits<generic_sorter>
-    {
-        using iterator_category = std::forward_iterator_tag;
-        using is_stable = std::true_type;
-    };
 }
 
 TEST_CASE( "hybrid_adapter over partial comparison sorter",

--- a/testsuite/adapters/hybrid_adapter_sfinae.cpp
+++ b/testsuite/adapters/hybrid_adapter_sfinae.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,6 @@
 #include <cpp-sort/adapters/hybrid_adapter.h>
 #include <cpp-sort/sort.h>
 #include <cpp-sort/sorter_facade.h>
-#include <cpp-sort/sorter_traits.h>
 #include <catch.hpp>
 
 namespace
@@ -54,6 +53,8 @@ namespace
         {
             return sorter_type::integer;
         }
+
+        using iterator_category = std::random_access_iterator_tag;
     };
 
     struct float_sorter_impl
@@ -69,6 +70,8 @@ namespace
         {
             return sorter_type::floating_point;
         }
+
+        using iterator_category = std::random_access_iterator_tag;
     };
 
     struct generic_sorter_impl
@@ -79,6 +82,8 @@ namespace
         {
             return sorter_type::generic;
         }
+
+        using iterator_category = std::random_access_iterator_tag;
     };
 
     struct integer_sorter:
@@ -92,30 +97,6 @@ namespace
     struct generic_sorter:
         cppsort::sorter_facade<generic_sorter_impl>
     {};
-}
-
-namespace cppsort
-{
-    template<>
-    struct sorter_traits<integer_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
-
-    template<>
-    struct sorter_traits<float_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
-
-    template<>
-    struct sorter_traits<generic_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 TEST_CASE( "sfinae forwarding in hybrid_adapter",

--- a/testsuite/adapters/small_array_adapter.cpp
+++ b/testsuite/adapters/small_array_adapter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,6 +46,8 @@ namespace
         {
             return std::distance(first, last) == N;
         }
+
+        using iterator_category = std::random_access_iterator_tag;
     };
 
     struct regular_sorter_impl
@@ -59,6 +61,8 @@ namespace
         {
             return false;
         }
+
+        using iterator_category = std::random_access_iterator_tag;
     };
 
     template<std::size_t N>
@@ -69,21 +73,6 @@ namespace
     struct regular_sorter:
         cppsort::sorter_facade<regular_sorter_impl>
     {};
-}
-
-namespace cppsort
-{
-    template<std::size_t N>
-    struct sorter_traits<fixed_sorter<N>>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-    };
-
-    template<>
-    struct sorter_traits<regular_sorter>
-    {
-        using iterator_category = std::random_access_iterator_tag;
-    };
 }
 
 TEST_CASE( "small array adapter",

--- a/testsuite/rebind_iterator_category.cpp
+++ b/testsuite/rebind_iterator_category.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,8 @@ namespace
         {
             return sorter_type::foo;
         }
+
+        using iterator_category = std::forward_iterator_tag;
     };
 
     struct bar_sorter_impl
@@ -58,6 +60,8 @@ namespace
         {
             return sorter_type::bar;
         }
+
+        using iterator_category = std::forward_iterator_tag;
     };
 
     struct foo_sorter:
@@ -67,23 +71,6 @@ namespace
     struct bar_sorter:
         cppsort::sorter_facade<bar_sorter_impl>
     {};
-}
-
-namespace cppsort
-{
-    template<>
-    struct sorter_traits<bar_sorter>
-    {
-        using iterator_category = std::forward_iterator_tag;
-        using is_stable = std::true_type;
-    };
-
-    template<>
-    struct sorter_traits<foo_sorter>
-    {
-        using iterator_category = std::forward_iterator_tag;
-        using is_stable = std::false_type;
-    };
 }
 
 TEST_CASE( "iterator category rebinder",


### PR DESCRIPTION
This branch gives to the generic version of `sorter_traits` the ability to find `is_stable` and `iterator_category` in the sorter it is passed, and uses this new ability to embed this information directly into the sorters and adapters when it is convenient instead of specializing `sorter_traits` (some sepcializations remain, still for convenience). Moreover, it goes to great lengths to make sure that the traits are as decoupled as possible. Ideally, when a trait is needed but another trait doesn't exist in a sorter, it should still compile more often than before.