### PR TITLE
Fixed sorter traits. Fixes #35.

### DIFF
--- a/include/cpp-sort/fixed/low_comparisons_sorter.h
+++ b/include/cpp-sort/fixed/low_comparisons_sorter.h
@@ -72,6 +72,7 @@ namespace cppsort
     template<>
     struct fixed_sorter_traits<low_comparisons_sorter>
     {
+        using domain = std::make_index_sequence<14>;
         using iterator_category = std::random_access_iterator_tag;
         using is_stable = std::false_type;
     };

--- a/include/cpp-sort/fixed/low_comparisons_sorter.h
+++ b/include/cpp-sort/fixed/low_comparisons_sorter.h
@@ -68,6 +68,13 @@ namespace cppsort
         // work...
         using is_stable = std::false_type;
     };
+
+    template<>
+    struct fixed_sorter_traits<low_comparisons_sorter>
+    {
+        using iterator_category = std::random_access_iterator_tag;
+        using is_stable = std::false_type;
+    };
 }
 
 // Specializations of low_comparisons_sorter for some values of N

--- a/include/cpp-sort/fixed/low_moves_sorter.h
+++ b/include/cpp-sort/fixed/low_moves_sorter.h
@@ -117,6 +117,13 @@ namespace cppsort
         // work...
         using is_stable = std::false_type;
     };
+
+    template<>
+    struct fixed_sorter_traits<low_moves_sorter>
+    {
+        using iterator_category = std::random_access_iterator_tag;
+        using is_stable = std::false_type;
+    };
 }
 
 // Specializations of low_moves_sorter for some values of N

--- a/include/cpp-sort/fixed/sorting_network_sorter.h
+++ b/include/cpp-sort/fixed/sorting_network_sorter.h
@@ -68,6 +68,13 @@ namespace cppsort
         // work...
         using is_stable = std::false_type;
     };
+
+    template<>
+    struct fixed_sorter_traits<sorting_network_sorter>
+    {
+        using iterator_category = std::random_access_iterator_tag;
+        using is_stable = std::false_type;
+    };
 }
 
 // Specializations of sorting_network_sorter for some values of N

--- a/include/cpp-sort/fixed/sorting_network_sorter.h
+++ b/include/cpp-sort/fixed/sorting_network_sorter.h
@@ -72,6 +72,7 @@ namespace cppsort
     template<>
     struct fixed_sorter_traits<sorting_network_sorter>
     {
+        using domain = std::make_index_sequence<33>;
         using iterator_category = std::random_access_iterator_tag;
         using is_stable = std::false_type;
     };

--- a/include/cpp-sort/sorter_traits.h
+++ b/include/cpp-sort/sorter_traits.h
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <cstddef>
 #include <functional>
 #include <iterator>
 #include <type_traits>
@@ -245,6 +246,15 @@ namespace cppsort
 
     template<typename Sorter>
     using is_stable = typename sorter_traits<Sorter>::is_stable;
+
+    ////////////////////////////////////////////////////////////
+    // Fixed-size sorter traits
+
+    template<template<std::size_t> class FixedSizeSorter>
+    struct fixed_sorter_traits
+    {
+        // Empty for SFINAE-friendliness
+    };
 
     ////////////////////////////////////////////////////////////
     // Sorter traits modifiers


### PR DESCRIPTION
This branch adds a new class template `fixed_sorter_traits` which provides information about a fixed-size sorter, and most notably contains the type `domain` which tells which specializations of a fixed-size sorter trait are actually usable. `small_array_adapter` is enhanced to take this information into account and automagically know for which sizes of arrays it is supposed to use the fixed-size sorter even when we don't explicitly feed the information to it. It will use `domain` if possible and consider that every specialization is valid if this type does not exist.