### PR TITLE
Add measures of presortedness. Fixes #48.

### DIFF
--- a/include/cpp-sort/detail/static_const.h
+++ b/include/cpp-sort/detail/static_const.h
@@ -1,0 +1,32 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2014
+//  Modified in 2016 by Morwenn for inclusion into cpp-sort
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef CPPSORT_DETAIL_STATIC_CONST_H_
+#define CPPSORT_DETAIL_STATIC_CONST_H_
+
+namespace cppsort
+{
+    namespace detail
+    {
+        template<typename T>
+        struct static_const
+        {
+            static constexpr T value {};
+        };
+
+        template<typename T>
+        constexpr T static_const<T>::value;
+    }
+}
+
+#endif // CPPSORT_DETAIL_STATIC_CONST_H_

--- a/include/cpp-sort/probes.h
+++ b/include/cpp-sort/probes.h
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_PROBES_H_
+#define CPPSORT_PROBES_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <cpp-sort/probes/osc.h>
+
+#endif // CPPSORT_PROBES_H_

--- a/include/cpp-sort/probes/dis.h
+++ b/include/cpp-sort/probes/dis.h
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_PROBES_DIS_H_
+#define CPPSORT_PROBES_DIS_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/as_function.h>
+#include <cpp-sort/utility/functional.h>
+#include "../detail/static_const.h"
+
+namespace cppsort
+{
+namespace probe
+{
+    namespace detail
+    {
+        struct dis_impl
+        {
+            template<
+                typename RandomAccessIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<
+                    is_projection_iterator<Projection, RandomAccessIterator, Compare>
+                >
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> typename std::iterator_traits<RandomAccessIterator>::difference_type
+            {
+                using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+                auto&& proj = utility::as_function(projection);
+
+                if (std::distance(first, last) < 2)
+                {
+                    return 0;
+                }
+
+                difference_type max_dist = 0;
+                for (auto it1 = first ; it1 != last ; ++it1)
+                {
+                    auto&& value = proj(*it1);
+                    for (auto it2 = std::next(it1) ; it2 != last ; ++it2)
+                    {
+                        if (compare(proj(*it2), value))
+                        {
+                            max_dist = std::max(
+                                max_dist,
+                                std::distance(it1, it2)
+                            );
+                        }
+                    }
+                }
+                return max_dist;
+            }
+        };
+    }
+
+    namespace
+    {
+        constexpr auto&& dis = cppsort::detail::static_const<
+            sorter_facade<detail::dis_impl>
+        >::value;
+    }
+}}
+
+#endif // CPPSORT_PROBES_DIS_H_

--- a/include/cpp-sort/probes/exc.h
+++ b/include/cpp-sort/probes/exc.h
@@ -1,0 +1,139 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_PROBES_EXC_H_
+#define CPPSORT_PROBES_EXC_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <algorithm>
+#include <cstdlib>
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <vector>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/sorters/pdq_sorter.h>
+#include <cpp-sort/utility/functional.h>
+#include "../detail/indirect_compare.h"
+#include "../detail/static_const.h"
+
+namespace cppsort
+{
+namespace probe
+{
+    namespace detail
+    {
+        struct exc_impl
+        {
+            template<
+                typename RandomAccessIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<
+                    is_projection_iterator<Projection, RandomAccessIterator, Compare>
+                >
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> typename std::iterator_traits<RandomAccessIterator>::difference_type
+            {
+                using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+
+                auto size = std::distance(first, last);
+                if (size < 2)
+                {
+                    return 0;
+                }
+
+                ////////////////////////////////////////////////////////////
+                // Indirectly sort the iterators
+
+                // Copy the iterators in a vector
+                std::vector<RandomAccessIterator> iterators;
+                iterators.reserve(size);
+                for (RandomAccessIterator it = first ; it != last ; ++it)
+                {
+                    iterators.push_back(it);
+                }
+
+                // Sort the iterators on pointed values
+                pdq_sorter{}(
+                    iterators,
+                    cppsort::detail::indirect_compare<Compare, Projection>(compare, projection)
+                );
+
+                ////////////////////////////////////////////////////////////
+                // Count the number of cycles
+
+                std::vector<bool> sorted(size, false);
+
+                // Element where the current cycle starts
+                RandomAccessIterator start = first;
+
+                difference_type cycles = 0;
+                while (start != last)
+                {
+                    // Find the element to put in current's place
+                    RandomAccessIterator current = start;
+                    auto next_pos = std::distance(first, current);
+                    RandomAccessIterator next = iterators[next_pos];
+                    sorted[next_pos] = true;
+
+                    // Process the current cycle
+                    if (next != current)
+                    {
+                        while (next != start)
+                        {
+                            current = next;
+                            auto next_pos = std::distance(first, next);
+                            next = iterators[next_pos];
+                            sorted[next_pos] = true;
+                        }
+                    }
+
+                    ++cycles;
+
+                    // Find the next cycle
+                    do
+                    {
+                        ++start;
+                    }
+                    while (start != last && sorted[start - first]);
+                }
+                return size - cycles;
+            }
+        };
+    }
+
+    namespace
+    {
+        constexpr auto&& exc = cppsort::detail::static_const<
+            sorter_facade<detail::exc_impl>
+        >::value;
+    }
+}}
+
+#endif // CPPSORT_PROBES_EXC_H_

--- a/include/cpp-sort/probes/ham.h
+++ b/include/cpp-sort/probes/ham.h
@@ -1,0 +1,109 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_PROBES_HAM_H_
+#define CPPSORT_PROBES_HAM_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <vector>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/sorters/pdq_sorter.h>
+#include <cpp-sort/utility/functional.h>
+#include "../detail/indirect_compare.h"
+#include "../detail/static_const.h"
+
+namespace cppsort
+{
+namespace probe
+{
+    namespace detail
+    {
+        struct ham_impl
+        {
+            template<
+                typename RandomAccessIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<
+                    is_projection_iterator<Projection, RandomAccessIterator, Compare>
+                >
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> typename std::iterator_traits<RandomAccessIterator>::difference_type
+            {
+                using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+
+                if (std::distance(first, last) < 2)
+                {
+                    return 0;
+                }
+
+                ////////////////////////////////////////////////////////////
+                // Indirectly sort the iterators
+
+                // Copy the iterators in a vector
+                std::vector<RandomAccessIterator> iterators;
+                iterators.reserve(std::distance(first, last));
+                for (RandomAccessIterator it = first ; it != last ; ++it)
+                {
+                    iterators.push_back(it);
+                }
+
+                // Sort the iterators on pointed values
+                pdq_sorter{}(
+                    iterators,
+                    cppsort::detail::indirect_compare<Compare, Projection>(compare, projection)
+                );
+
+                ////////////////////////////////////////////////////////////
+                // Count the number of values not in place
+
+                difference_type count = 0;
+                for (auto&& it: iterators)
+                {
+                    if (it != first++)
+                    {
+                        ++count;
+                    }
+                }
+                return count;
+            }
+        };
+    }
+
+    namespace
+    {
+        constexpr auto&& ham = cppsort::detail::static_const<
+            sorter_facade<detail::ham_impl>
+        >::value;
+    }
+}}
+
+#endif // CPPSORT_PROBES_HAM_H_

--- a/include/cpp-sort/probes/inv.h
+++ b/include/cpp-sort/probes/inv.h
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_PROBES_INV_H_
+#define CPPSORT_PROBES_INV_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/as_function.h>
+#include <cpp-sort/utility/functional.h>
+#include "../detail/static_const.h"
+
+namespace cppsort
+{
+namespace probe
+{
+    namespace detail
+    {
+        struct inv_impl
+        {
+            template<
+                typename RandomAccessIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<
+                    is_projection_iterator<Projection, RandomAccessIterator, Compare>
+                >
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> typename std::iterator_traits<RandomAccessIterator>::difference_type
+            {
+                using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+                auto&& proj = utility::as_function(projection);
+
+                if (std::distance(first, last) < 2)
+                {
+                    return 0;
+                }
+
+                difference_type count = 0;
+                for (auto it1 = first ; it1 != last ; ++it1)
+                {
+                    auto&& value = proj(*it1);
+                    for (auto it2 = std::next(it1) ; it2 != last ; ++it2)
+                    {
+                        if (compare(proj(*it2), value))
+                        {
+                            ++count;
+                        }
+                    }
+                }
+                return count;
+            }
+        };
+    }
+
+    namespace
+    {
+        constexpr auto&& inv = cppsort::detail::static_const<
+            sorter_facade<detail::inv_impl>
+        >::value;
+    }
+}}
+
+#endif // CPPSORT_PROBES_INV_H_

--- a/include/cpp-sort/probes/max.h
+++ b/include/cpp-sort/probes/max.h
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_PROBES_MAX_H_
+#define CPPSORT_PROBES_MAX_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <algorithm>
+#include <cstdlib>
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <vector>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/sorters/pdq_sorter.h>
+#include <cpp-sort/utility/functional.h>
+#include "../detail/indirect_compare.h"
+#include "../detail/static_const.h"
+
+namespace cppsort
+{
+namespace probe
+{
+    namespace detail
+    {
+        struct max_impl
+        {
+            template<
+                typename RandomAccessIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<
+                    is_projection_iterator<Projection, RandomAccessIterator, Compare>
+                >
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> typename std::iterator_traits<RandomAccessIterator>::difference_type
+            {
+                using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+
+                auto size = std::distance(first, last);
+                if (size < 2)
+                {
+                    return 0;
+                }
+
+                ////////////////////////////////////////////////////////////
+                // Indirectly sort the iterators
+
+                // Copy the iterators in a vector
+                std::vector<RandomAccessIterator> iterators;
+                iterators.reserve(size);
+                for (RandomAccessIterator it = first ; it != last ; ++it)
+                {
+                    iterators.push_back(it);
+                }
+
+                // Sort the iterators on pointed values
+                pdq_sorter{}(
+                    iterators,
+                    cppsort::detail::indirect_compare<Compare, Projection>(compare, projection)
+                );
+
+                ////////////////////////////////////////////////////////////
+                // Maximum distance an element has to travel in order to
+                // reach its sorted position
+
+                difference_type max_dist = 0;
+                for (difference_type i = 0 ; i < size ; ++i)
+                {
+                    auto dist = std::distance(first, iterators[i]);
+                    max_dist = std::max(std::abs(dist - i), max_dist);
+                }
+                return max_dist;
+            }
+        };
+    }
+
+    namespace
+    {
+        constexpr auto&& max = cppsort::detail::static_const<
+            sorter_facade<detail::max_impl>
+        >::value;
+    }
+}}
+
+#endif // CPPSORT_PROBES_MAX_H_

--- a/include/cpp-sort/probes/osc.h
+++ b/include/cpp-sort/probes/osc.h
@@ -1,0 +1,101 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_PROBES_OSC_H_
+#define CPPSORT_PROBES_OSC_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/as_function.h>
+#include <cpp-sort/utility/functional.h>
+#include "../detail/static_const.h"
+
+namespace cppsort
+{
+namespace probe
+{
+    namespace detail
+    {
+        struct osc_impl
+        {
+            template<
+                typename RandomAccessIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<
+                    is_projection_iterator<Projection, RandomAccessIterator, Compare>
+                >
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> typename std::iterator_traits<RandomAccessIterator>::difference_type
+            {
+                using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+                auto&& proj = utility::as_function(projection);
+
+                if (std::distance(first, last) < 2)
+                {
+                    return 0;
+                }
+
+                difference_type count = 0;
+                for (auto it = first ; it != last ; ++it)
+                {
+                    auto&& value = proj(*it);
+
+                    auto current = first;
+                    auto next = std::next(first);
+
+                    while (next != last)
+                    {
+                        if (compare(std::min(proj(*current), proj(*next)), value) &&
+                            compare(value, std::max(proj(*current), proj(*next))))
+                        {
+                            ++count;
+                        }
+
+                        ++current;
+                        ++next;
+                    }
+                }
+                return count;
+            }
+        };
+    }
+
+    namespace
+    {
+        constexpr auto&& osc = cppsort::detail::static_const<
+            sorter_facade<detail::osc_impl>
+        >::value;
+    }
+}}
+
+#endif // CPPSORT_PROBES_OSC_H_

--- a/include/cpp-sort/probes/rem.h
+++ b/include/cpp-sort/probes/rem.h
@@ -1,0 +1,107 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_PROBES_REM_H_
+#define CPPSORT_PROBES_REM_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/as_function.h>
+#include <cpp-sort/utility/functional.h>
+#include "../detail/static_const.h"
+
+namespace cppsort
+{
+namespace probe
+{
+    namespace detail
+    {
+        struct rem_impl
+        {
+            template<
+                typename RandomAccessIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<
+                    is_projection_iterator<Projection, RandomAccessIterator, Compare>
+                >
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> typename std::iterator_traits<RandomAccessIterator>::difference_type
+            {
+                using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+                auto&& proj = utility::as_function(projection);
+
+                if (std::distance(first, last) < 2)
+                {
+                    return 0;
+                }
+
+                // Size of the longest ascending subsequence
+                difference_type max_size = 0;
+                // Beginning of the current subsequence
+                auto begin = first;
+
+                auto current = first;
+                auto next = std::next(first);
+                while (true)
+                {
+                    while (next != last && compare(proj(*current), proj(*next)))
+                    {
+                        ++current;
+                        ++next;
+                    }
+
+                    max_size = std::max(
+                        max_size,
+                        std::distance(begin, next)
+                    );
+
+                    if (next == last) break;
+                    ++current;
+                    ++next;
+                    begin = current;
+                }
+
+                return std::distance(first, last) - max_size;
+            }
+        };
+    }
+
+    namespace
+    {
+        constexpr auto&& rem = cppsort::detail::static_const<
+            sorter_facade<detail::rem_impl>
+        >::value;
+    }
+}}
+
+#endif // CPPSORT_PROBES_REM_H_

--- a/include/cpp-sort/probes/runs.h
+++ b/include/cpp-sort/probes/runs.h
@@ -1,0 +1,97 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_PROBES_RUNS_H_
+#define CPPSORT_PROBES_RUNS_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/as_function.h>
+#include <cpp-sort/utility/functional.h>
+#include "../detail/static_const.h"
+
+namespace cppsort
+{
+namespace probe
+{
+    namespace detail
+    {
+        struct runs_impl
+        {
+            template<
+                typename RandomAccessIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<
+                    is_projection_iterator<Projection, RandomAccessIterator, Compare>
+                >
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> typename std::iterator_traits<RandomAccessIterator>::difference_type
+            {
+                using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+                auto&& proj = utility::as_function(projection);
+
+                if (std::distance(first, last) < 2)
+                {
+                    return 1;
+                }
+
+                auto current = first;
+                auto next = std::next(first);
+
+                difference_type count = 0;
+                while (true)
+                {
+                    while (next != last && compare(proj(*current), proj(*next)))
+                    {
+                        ++current;
+                        ++next;
+                    }
+
+                    ++count;
+                    if (next == last) break;
+                    ++current;
+                    ++next;
+                }
+                return count;
+            }
+        };
+    }
+
+    namespace
+    {
+        constexpr auto&& runs = cppsort::detail::static_const<
+            sorter_facade<detail::runs_impl>
+        >::value;
+    }
+}}
+
+#endif // CPPSORT_PROBES_RUNS_H_

--- a/include/cpp-sort/probes/runs.h
+++ b/include/cpp-sort/probes/runs.h
@@ -61,7 +61,7 @@ namespace probe
 
                 if (std::distance(first, last) < 2)
                 {
-                    return 1;
+                    return 0;
                 }
 
                 auto current = first;
@@ -76,8 +76,8 @@ namespace probe
                         ++next;
                     }
 
-                    ++count;
                     if (next == last) break;
+                    ++count;
                     ++current;
                     ++next;
                 }

--- a/include/cpp-sort/utility/as_function.h
+++ b/include/cpp-sort/utility/as_function.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <type_traits>
 #include <utility>
+#include "../detail/static_const.h"
 
 namespace cppsort
 {
@@ -26,19 +27,6 @@ namespace utility
 {
     namespace detail
     {
-        // static_const
-
-        template<typename T>
-        struct static_const
-        {
-            static constexpr T value {};
-        };
-
-        template<typename T>
-        constexpr T static_const<T>::value;
-
-        // as_function
-
         struct as_function_fn
         {
         private:
@@ -82,8 +70,9 @@ namespace utility
 
     namespace
     {
-        constexpr auto&& as_function
-            = detail::static_const<detail::as_function_fn>::value;
+        constexpr auto&& as_function = cppsort::detail::static_const<
+            detail::as_function_fn
+        >::value;
     }
 }}
 

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
 set(
     PROBES_TESTS
 
+    probes/exc.cpp
     probes/ham.cpp
     probes/inv.cpp
     probes/max.cpp

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${CATCH_INCLUDE_DIR})
 # Define test files
 
 set(
-    ADAPTER_TESTS
+    ADAPTERS_TESTS
 
     adapters/counting_adapter.cpp
     adapters/hybrid_adapter_partial_compare.cpp
@@ -13,6 +13,12 @@ set(
     adapters/indirect_adapter_every_sorter.cpp
     adapters/self_sort_adapter_no_compare.cpp
     adapters/small_array_adapter.cpp
+)
+
+set(
+    PROBES_TESTS
+
+    probes/osc.cpp
 )
 
 set(
@@ -44,7 +50,8 @@ add_executable(
     sorter_facade.cpp
     sorter_facade_defaults.cpp
     sorter_facade_iterable.cpp
-    ${ADAPTER_TESTS}
+    ${ADAPTERS_TESTS}
+    ${PROBES_TESTS}
     ${SORTERS_TESTS}
     ${UTILITY_TESTS}
 )

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
 set(
     PROBES_TESTS
 
+    probes/ham.cpp
     probes/inv.cpp
     probes/osc.cpp
     probes/rem.cpp

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
 set(
     PROBES_TESTS
 
+    probes/inv.cpp
     probes/osc.cpp
     probes/runs.cpp
 )

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -20,6 +20,7 @@ set(
 
     probes/ham.cpp
     probes/inv.cpp
+    probes/max.cpp
     probes/osc.cpp
     probes/rem.cpp
     probes/runs.cpp

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
     PROBES_TESTS
 
     probes/osc.cpp
+    probes/runs.cpp
 )
 
 set(

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
 set(
     PROBES_TESTS
 
+    probes/dis.cpp
     probes/exc.cpp
     probes/ham.cpp
     probes/inv.cpp

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -20,6 +20,7 @@ set(
 
     probes/inv.cpp
     probes/osc.cpp
+    probes/rem.cpp
     probes/runs.cpp
 )
 

--- a/testsuite/probes/dis.cpp
+++ b/testsuite/probes/dis.cpp
@@ -21,19 +21,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef CPPSORT_PROBES_H_
-#define CPPSORT_PROBES_H_
-
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
 #include <cpp-sort/probes/dis.h>
-#include <cpp-sort/probes/exc.h>
-#include <cpp-sort/probes/ham.h>
-#include <cpp-sort/probes/inv.h>
-#include <cpp-sort/probes/max.h>
-#include <cpp-sort/probes/osc.h>
-#include <cpp-sort/probes/rem.h>
-#include <cpp-sort/probes/runs.h>
 
-#endif // CPPSORT_PROBES_H_
+TEST_CASE( "presortedness measure: dis", "[probe][dis]" )
+{
+    SECTION( "simple test" )
+    {
+        std::vector<int> vec = { 47, 53, 46, 41, 59, 81, 74, 97, 100, 45 };
+        CHECK( cppsort::probe::dis(vec) == 9 );
+        CHECK( cppsort::probe::dis(std::begin(vec), std::end(vec)) == 9 );
+    }
+
+    SECTION( "lower bound" )
+    {
+        std::vector<int> vec = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        CHECK( cppsort::probe::dis(vec) == 0 );
+        CHECK( cppsort::probe::dis(std::begin(vec), std::end(vec)) == 0 );
+    }
+
+    SECTION( "upper bound" )
+    {
+        // The upper bound should correspond to the size of
+        // the input sequence minus one
+
+        std::vector<int> vec = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+        CHECK( cppsort::probe::dis(vec) == 10 );
+        CHECK( cppsort::probe::dis(std::begin(vec), std::end(vec)) == 10 );
+    }
+}

--- a/testsuite/probes/exc.cpp
+++ b/testsuite/probes/exc.cpp
@@ -21,18 +21,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef CPPSORT_PROBES_H_
-#define CPPSORT_PROBES_H_
-
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
 #include <cpp-sort/probes/exc.h>
-#include <cpp-sort/probes/ham.h>
-#include <cpp-sort/probes/inv.h>
-#include <cpp-sort/probes/max.h>
-#include <cpp-sort/probes/osc.h>
-#include <cpp-sort/probes/rem.h>
-#include <cpp-sort/probes/runs.h>
 
-#endif // CPPSORT_PROBES_H_
+TEST_CASE( "presortedness measure: exc", "[probe][exc]" )
+{
+    SECTION( "simple test" )
+    {
+        std::vector<int> vec = { 74, 59, 62, 23, 86, 69, 18, 52, 77, 68 };
+        CHECK( cppsort::probe::exc(vec) == 7 );
+        CHECK( cppsort::probe::exc(std::begin(vec), std::end(vec)) == 7 );
+
+        std::vector<int> vec2 = { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+        CHECK( cppsort::probe::exc(vec2) == 5 );
+        CHECK( cppsort::probe::exc(std::begin(vec2), std::end(vec2)) == 5 );
+    }
+
+    SECTION( "lower bound" )
+    {
+        std::vector<int> vec = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        CHECK( cppsort::probe::exc(vec) == 0 );
+        CHECK( cppsort::probe::exc(std::begin(vec), std::end(vec)) == 0 );
+    }
+
+    SECTION( "upper bound" )
+    {
+        // The upper bound should correspond to the size of
+        // the input sequence minus one
+
+        std::vector<int> vec = { 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        CHECK( cppsort::probe::exc(vec) == 10 );
+        CHECK( cppsort::probe::exc(std::begin(vec), std::end(vec)) == 10 );
+    }
+}

--- a/testsuite/probes/ham.cpp
+++ b/testsuite/probes/ham.cpp
@@ -21,16 +21,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef CPPSORT_PROBES_H_
-#define CPPSORT_PROBES_H_
-
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
 #include <cpp-sort/probes/ham.h>
-#include <cpp-sort/probes/inv.h>
-#include <cpp-sort/probes/osc.h>
-#include <cpp-sort/probes/rem.h>
-#include <cpp-sort/probes/runs.h>
 
-#endif // CPPSORT_PROBES_H_
+TEST_CASE( "presortedness measure: ham", "[probe][ham]" )
+{
+    SECTION( "simple test" )
+    {
+        std::vector<int> vec = { 34, 43, 96, 42, 44, 48, 57, 42, 68, 69 };
+        CHECK( cppsort::probe::ham(vec) == 6 );
+        CHECK( cppsort::probe::ham(std::begin(vec), std::end(vec)) == 6 );
+    }
+
+    SECTION( "lower bound" )
+    {
+        std::vector<int> vec = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        CHECK( cppsort::probe::ham(vec) == 0 );
+        CHECK( cppsort::probe::ham(std::begin(vec), std::end(vec)) == 0 );
+    }
+
+    SECTION( "upper bound" )
+    {
+        // The upper bound should correspond to the size of
+        // the input sequence
+
+        std::vector<int> vec = { 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        CHECK( cppsort::probe::ham(vec) == 11 );
+        CHECK( cppsort::probe::ham(std::begin(vec), std::end(vec)) == 11 );
+    }
+}

--- a/testsuite/probes/inv.cpp
+++ b/testsuite/probes/inv.cpp
@@ -44,7 +44,7 @@ TEST_CASE( "presortedness measure: inv", "[probe][inv]" )
 
     SECTION( "upper bound" )
     {
-        // The upper bound should correspond be:
+        // The upper bound should correspond to:
         // size * (size - 1) / 2
 
         std::vector<int> vec = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };

--- a/testsuite/probes/inv.cpp
+++ b/testsuite/probes/inv.cpp
@@ -21,14 +21,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef CPPSORT_PROBES_H_
-#define CPPSORT_PROBES_H_
-
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
 #include <cpp-sort/probes/inv.h>
-#include <cpp-sort/probes/osc.h>
-#include <cpp-sort/probes/runs.h>
 
-#endif // CPPSORT_PROBES_H_
+TEST_CASE( "presortedness measure: inv", "[probe][inv]" )
+{
+    SECTION( "simple test" )
+    {
+        std::vector<int> vec = { 48, 43, 96, 44, 42, 34, 42, 57, 68, 69 };
+        CHECK( cppsort::probe::inv(vec) == 19 );
+        CHECK( cppsort::probe::inv(std::begin(vec), std::end(vec)) == 19 );
+    }
+
+    SECTION( "lower bound" )
+    {
+        std::vector<int> vec = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        CHECK( cppsort::probe::inv(vec) == 0 );
+        CHECK( cppsort::probe::inv(std::begin(vec), std::end(vec)) == 0 );
+    }
+
+    SECTION( "upper bound" )
+    {
+        // The upper bound should correspond be:
+        // size * (size - 1) / 2
+
+        std::vector<int> vec = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+        CHECK( cppsort::probe::inv(vec) == 55 );
+        CHECK( cppsort::probe::inv(std::begin(vec), std::end(vec)) == 55 );
+    }
+}

--- a/testsuite/probes/max.cpp
+++ b/testsuite/probes/max.cpp
@@ -21,17 +21,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef CPPSORT_PROBES_H_
-#define CPPSORT_PROBES_H_
-
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
-#include <cpp-sort/probes/ham.h>
-#include <cpp-sort/probes/inv.h>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
 #include <cpp-sort/probes/max.h>
-#include <cpp-sort/probes/osc.h>
-#include <cpp-sort/probes/rem.h>
-#include <cpp-sort/probes/runs.h>
 
-#endif // CPPSORT_PROBES_H_
+TEST_CASE( "presortedness measure: max", "[probe][max]" )
+{
+    SECTION( "simple test" )
+    {
+        std::vector<int> vec = { 12, 28, 17, 59, 13, 10, 39, 21, 31, 30 };
+        CHECK( cppsort::probe::max(vec) == 6 );
+        CHECK( cppsort::probe::max(std::begin(vec), std::end(vec)) == 6 );
+    }
+
+    SECTION( "lower bound" )
+    {
+        std::vector<int> vec = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        CHECK( cppsort::probe::max(vec) == 0 );
+        CHECK( cppsort::probe::max(std::begin(vec), std::end(vec)) == 0 );
+    }
+
+    SECTION( "upper bound" )
+    {
+        // The upper bound should correspond to the size of
+        // the input sequence minus one
+
+        std::vector<int> vec = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+        CHECK( cppsort::probe::max(vec) == 10 );
+        CHECK( cppsort::probe::max(std::begin(vec), std::end(vec)) == 10 );
+    }
+}

--- a/testsuite/probes/osc.cpp
+++ b/testsuite/probes/osc.cpp
@@ -48,7 +48,7 @@ TEST_CASE( "presortedness measure: osc", "[probe][osc]" )
     SECTION( "upper bound" )
     {
         // Example from the paper Adaptative Heapsort
-        // by Levcopoulos and Petersson, that upper bound
+        // by Levcopoulos and Petersson, the upper bound
         // should be (size * (size - 2) - 1) / 2
 
         std::vector<int> vec = { 8, 5, 10, 3, 12, 1, 13, 2, 11, 4, 9, 6, 7 };

--- a/testsuite/probes/osc.cpp
+++ b/testsuite/probes/osc.cpp
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/probes/osc.h>
+
+TEST_CASE( "presortedness measure: osc", "[probe][osc]" )
+{
+    SECTION( "simple test" )
+    {
+        // Example from the paper Adaptative Heapsort
+        // by Levcopoulos and Petersson
+
+        std::vector<int> vec = { 6, 3, 9, 8, 4, 7, 1, 11 };
+        CHECK( cppsort::probe::osc(vec) == 17 );
+        CHECK( cppsort::probe::osc(std::begin(vec), std::end(vec)) == 17 );
+    }
+
+    SECTION( "lower bound" )
+    {
+        std::vector<int> vec = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        CHECK( cppsort::probe::osc(vec) == 0 );
+        CHECK( cppsort::probe::osc(std::begin(vec), std::end(vec)) == 0 );
+    }
+
+    SECTION( "upper bound" )
+    {
+        // Example from the paper Adaptative Heapsort
+        // by Levcopoulos and Petersson, that upper bound
+        // should be (size * (size - 2) - 1) / 2
+
+        std::vector<int> vec = { 8, 5, 10, 3, 12, 1, 13, 2, 11, 4, 9, 6, 7 };
+        CHECK( cppsort::probe::osc(vec) == 71 );
+        CHECK( cppsort::probe::osc(std::begin(vec), std::end(vec)) == 71 );
+    }
+}

--- a/testsuite/probes/rem.cpp
+++ b/testsuite/probes/rem.cpp
@@ -21,15 +21,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef CPPSORT_PROBES_H_
-#define CPPSORT_PROBES_H_
-
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
-#include <cpp-sort/probes/inv.h>
-#include <cpp-sort/probes/osc.h>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
 #include <cpp-sort/probes/rem.h>
-#include <cpp-sort/probes/runs.h>
 
-#endif // CPPSORT_PROBES_H_
+TEST_CASE( "presortedness measure: rem", "[probe][rem]" )
+{
+    SECTION( "simple test" )
+    {
+        std::vector<int> vec = { 6, 9, 79, 41, 44, 49, 11, 16, 69, 15 };
+        CHECK( cppsort::probe::rem(vec) == 7 );
+        CHECK( cppsort::probe::rem(std::begin(vec), std::end(vec)) == 7 );
+    }
+
+    SECTION( "lower bound" )
+    {
+        std::vector<int> vec = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        CHECK( cppsort::probe::rem(vec) == 0 );
+        CHECK( cppsort::probe::rem(std::begin(vec), std::end(vec)) == 0 );
+    }
+
+    SECTION( "upper bound" )
+    {
+        // The upper bound should correspond to the size of
+        // the input sequence minus one
+
+        std::vector<int> vec = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+        CHECK( cppsort::probe::rem(vec) == 10 );
+        CHECK( cppsort::probe::rem(std::begin(vec), std::end(vec)) == 10 );
+    }
+}

--- a/testsuite/probes/runs.cpp
+++ b/testsuite/probes/runs.cpp
@@ -28,18 +28,24 @@
 
 TEST_CASE( "presortedness measure: runs", "[probe][runs]" )
 {
-    SECTION( "simple test" )
+    SECTION( "simple tests" )
     {
         std::vector<int> vec = { 40, 49, 58, 99, 60, 70, 12, 87, 9, 8, 82, 91, 99, 67, 82, 92 };
-        CHECK( cppsort::probe::runs(vec) == 6 );
-        CHECK( cppsort::probe::runs(std::begin(vec), std::end(vec)) == 6 );
+        CHECK( cppsort::probe::runs(vec) == 5 );
+        CHECK( cppsort::probe::runs(std::begin(vec), std::end(vec)) == 5 );
+
+        // From Right invariant metrics and measures of
+        // presortedness by Estivill-Castro, Mannila and Wood
+        std::vector<int> vec2 = { 4, 2, 6, 5, 3, 1, 9, 7, 10, 8 };
+        CHECK( cppsort::probe::runs(vec2) == 6 );
+        CHECK( cppsort::probe::runs(std::begin(vec2), std::end(vec2)) == 6 );
     }
 
     SECTION( "lower bound" )
     {
         std::vector<int> vec = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-        CHECK( cppsort::probe::runs(vec) == 1 );
-        CHECK( cppsort::probe::runs(std::begin(vec), std::end(vec)) == 1 );
+        CHECK( cppsort::probe::runs(vec) == 0 );
+        CHECK( cppsort::probe::runs(std::begin(vec), std::end(vec)) == 0 );
     }
 
     SECTION( "upper bound" )
@@ -48,7 +54,7 @@ TEST_CASE( "presortedness measure: runs", "[probe][runs]" )
         // the input sequence
 
         std::vector<int> vec = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-        CHECK( cppsort::probe::runs(vec) == 11 );
-        CHECK( cppsort::probe::runs(std::begin(vec), std::end(vec)) == 11 );
+        CHECK( cppsort::probe::runs(vec) == 10 );
+        CHECK( cppsort::probe::runs(std::begin(vec), std::end(vec)) == 10 );
     }
 }

--- a/testsuite/probes/runs.cpp
+++ b/testsuite/probes/runs.cpp
@@ -51,7 +51,7 @@ TEST_CASE( "presortedness measure: runs", "[probe][runs]" )
     SECTION( "upper bound" )
     {
         // The upper bound should correspond to the size of
-        // the input sequence
+        // the input sequence minus one
 
         std::vector<int> vec = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
         CHECK( cppsort::probe::runs(vec) == 10 );

--- a/testsuite/probes/runs.cpp
+++ b/testsuite/probes/runs.cpp
@@ -21,13 +21,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef CPPSORT_PROBES_H_
-#define CPPSORT_PROBES_H_
-
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
-#include <cpp-sort/probes/osc.h>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
 #include <cpp-sort/probes/runs.h>
 
-#endif // CPPSORT_PROBES_H_
+TEST_CASE( "presortedness measure: runs", "[probe][runs]" )
+{
+    SECTION( "simple test" )
+    {
+        std::vector<int> vec = { 40, 49, 58, 99, 60, 70, 12, 87, 9, 8, 82, 91, 99, 67, 82, 92 };
+        CHECK( cppsort::probe::runs(vec) == 6 );
+        CHECK( cppsort::probe::runs(std::begin(vec), std::end(vec)) == 6 );
+    }
+
+    SECTION( "lower bound" )
+    {
+        std::vector<int> vec = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        CHECK( cppsort::probe::runs(vec) == 1 );
+        CHECK( cppsort::probe::runs(std::begin(vec), std::end(vec)) == 1 );
+    }
+
+    SECTION( "upper bound" )
+    {
+        // The upper bound should correspond to the size of
+        // the input sequence
+
+        std::vector<int> vec = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+        CHECK( cppsort::probe::runs(vec) == 11 );
+        CHECK( cppsort::probe::runs(std::begin(vec), std::end(vec)) == 11 );
+    }
+}


### PR DESCRIPTION
Add 8 standard measures of presortedness to the library in the `probe` subnamespace, complete with tests and documentation. More such measures could be added later but it's enough for now. These measures use `sorter_facade` behind the scenes to provide a full support for custom comparison and projection functions, with automatic additional overloads for `std::less<>` and `utility::identity` and ranges, and everything we want them to work with...