### PR TITLE
Add a poplar_sorter to the library.

### DIFF
--- a/include/cpp-sort/detail/poplar_sort.h
+++ b/include/cpp-sort/detail/poplar_sort.h
@@ -103,9 +103,22 @@ namespace detail
             return;
         }
 
+        auto&& proj = utility::as_function(projection);
+
         auto middle = first + size / 2;
         make_poplar(first, middle, compare, projection);
         make_poplar(middle, std::prev(last), compare, projection);
+
+        // Make sure that the poplar on the right has a bigger root
+        // that the one on the left. Apparently, it makes things
+        // faster, probably helping the branch predictor or
+        // something...
+        if (compare(proj(*(last - 2)), proj(*std::prev(middle))))
+        {
+            std::iter_swap(std::prev(middle), last - 2);
+            sift(first - 1, middle - first, compare, projection);
+        }
+
         sift(first - 1, size, compare, projection);
     }
 

--- a/include/cpp-sort/sorters.h
+++ b/include/cpp-sort/sorters.h
@@ -35,6 +35,7 @@
 #include <cpp-sort/sorters/merge_insertion_sorter.h>
 #include <cpp-sort/sorters/merge_sorter.h>
 #include <cpp-sort/sorters/pdq_sorter.h>
+#include <cpp-sort/sorters/poplar_sorter.h>
 #include <cpp-sort/sorters/quick_sorter.h>
 #include <cpp-sort/sorters/selection_sorter.h>
 #include <cpp-sort/sorters/smooth_sorter.h>

--- a/include/cpp-sort/sorters/poplar_sorter.h
+++ b/include/cpp-sort/sorters/poplar_sorter.h
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_SORTERS_POPLAR_SORTER_H_
+#define CPPSORT_SORTERS_POPLAR_SORTER_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/functional.h>
+#include "../detail/poplar_sort.h"
+
+namespace cppsort
+{
+    ////////////////////////////////////////////////////////////
+    // Sorter
+
+    namespace detail
+    {
+        struct poplar_sorter_impl
+        {
+            template<
+                typename RandomAccessIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<
+                    is_projection_iterator<Projection, RandomAccessIterator, Compare>
+                >
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> void
+            {
+                static_assert(
+                    std::is_base_of<
+                        std::random_access_iterator_tag,
+                        typename std::iterator_traits<RandomAccessIterator>::iterator_category
+                    >::value,
+                    "poplar_sorter requires at least random-access iterators"
+                );
+
+                poplar_sort(first, last, compare, projection);
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_stable = std::false_type;
+        };
+    }
+
+    struct poplar_sorter:
+        sorter_facade<detail::poplar_sorter_impl>
+    {};
+}
+
+#endif // CPPSORT_SORTERS_POPLAR_SORTER_H_


### PR DESCRIPTION
The new `poplar_sorter` implements a *poplar sort* which is a heapsort derivative described by Coenraad Bron and Wim H. Hesselink in *Smoothsort revisited*. While heapsort uses a balanced binary heap and smoothsort uses a Leonardo heap, poplar sort uses a forest of perfect binary heaps whose root is stored on the right to make sure that the bigger elements in the collection are closer to their sorted position and thus to increase locality.