### PR TITLE
Automagic projections. Fixes #36.

### DIFF
--- a/include/cpp-sort/detail/projection_compare.h
+++ b/include/cpp-sort/detail/projection_compare.h
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_DETAIL_PROJECTION_COMPARE_H_
+#define CPPSORT_DETAIL_PROJECTION_COMPARE_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <utility>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/as_function.h>
+
+namespace cppsort
+{
+namespace detail
+{
+    template<typename Compare, typename Projection>
+    class projection_compare
+    {
+        private:
+
+            using projection_t = decltype(utility::as_function(std::declval<Projection&>()));
+
+            Compare compare;
+            projection_t proj;
+
+        public:
+
+            projection_compare(Compare compare, Projection projection):
+                compare(compare),
+                proj(utility::as_function(projection))
+            {}
+
+            template<typename T, typename U>
+            auto operator()(T&& lhs, U&& rhs)
+                noexcept(noexcept(compare(proj(std::forward<T>(lhs)), proj(std::forward<U>(rhs)))))
+                -> decltype(compare(proj(std::forward<T>(lhs)), proj(std::forward<U>(rhs))))
+            {
+                return compare(proj(std::forward<T>(lhs)), proj(std::forward<U>(rhs)));
+            }
+    };
+
+    template<typename Compare, typename Projection>
+    auto make_projection_compare(Compare compare, Projection projection)
+        -> projection_compare<Compare, Projection>
+    {
+        return { compare, projection };
+    }
+}}
+
+#endif // CPPSORT_DETAIL_PROJECTION_COMPARE_H_

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -32,6 +32,7 @@
 #include <iterator>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
 
 namespace cppsort
 {
@@ -44,7 +45,10 @@ namespace cppsort
         {
             template<
                 typename RandomAccessIterator,
-                typename Compare = std::less<>
+                typename Compare = std::less<>,
+                typename = std::enable_if_t<not is_projection_iterator<
+                    Compare, RandomAccessIterator
+                >>
             >
             auto operator()(RandomAccessIterator first, RandomAccessIterator last,
                             Compare compare={}) const

--- a/include/cpp-sort/sorters/std_stable_sorter.h
+++ b/include/cpp-sort/sorters/std_stable_sorter.h
@@ -32,6 +32,7 @@
 #include <iterator>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
 
 namespace cppsort
 {
@@ -44,7 +45,10 @@ namespace cppsort
         {
             template<
                 typename RandomAccessIterator,
-                typename Compare = std::less<>
+                typename Compare = std::less<>,
+                typename = std::enable_if_t<not is_projection_iterator<
+                    Compare, RandomAccessIterator
+                >>
             >
             auto operator()(RandomAccessIterator first, RandomAccessIterator last,
                             Compare compare={}) const

--- a/testsuite/sorters/std_sorter.cpp
+++ b/testsuite/sorters/std_sorter.cpp
@@ -1,0 +1,108 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <ctime>
+#include <functional>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sorters/std_sorter.h>
+#include <cpp-sort/sort.h>
+#include "../algorithm.h"
+
+TEST_CASE( "std_sorter tests", "[std_sorter]" )
+{
+    // Pseudo-random number engine
+    std::mt19937_64 engine(std::time(nullptr));
+
+    // Collection to sort
+    std::vector<int> vec(80);
+    std::iota(std::begin(vec), std::end(vec), 0);
+    std::shuffle(std::begin(vec), std::end(vec), engine);
+
+    SECTION( "sort with iterable" )
+    {
+        cppsort::sort(vec, cppsort::std_sorter{});
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+    }
+
+    SECTION( "sort with iterable and compare" )
+    {
+        cppsort::sort(vec, cppsort::std_sorter{}, std::greater<>{});
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+    }
+
+    SECTION( "sort with iterators" )
+    {
+        cppsort::sort(std::begin(vec), std::end(vec), cppsort::std_sorter{});
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+    }
+
+    SECTION( "sort with iterators and compare" )
+    {
+        cppsort::sort(std::begin(vec), std::end(vec), cppsort::std_sorter{}, std::greater<>{});
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+    }
+}
+
+TEST_CASE( "std_sorter tests with projections",
+           "[std_sorter][projection]" )
+{
+    // Pseudo-random number engine
+    std::mt19937_64 engine(std::time(nullptr));
+
+    // Wrapper to hide the integer
+    struct wrapper { int value; };
+
+    // Collection to sort
+    std::vector<wrapper> vec(80);
+    helpers::iota(std::begin(vec), std::end(vec), 0, &wrapper::value);
+    std::shuffle(std::begin(vec), std::end(vec), engine);
+
+    SECTION( "sort with iterable" )
+    {
+        cppsort::sort(vec, cppsort::std_sorter{}, &wrapper::value);
+        CHECK( helpers::is_sorted(std::begin(vec), std::end(vec), std::less<>{}, &wrapper::value) );
+    }
+
+    SECTION( "sort with iterable and compare" )
+    {
+        cppsort::sort(vec, cppsort::std_sorter{}, std::greater<>{}, &wrapper::value);
+        CHECK( helpers::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}, &wrapper::value) );
+    }
+
+    SECTION( "sort with iterators" )
+    {
+        cppsort::sort(std::begin(vec), std::end(vec), cppsort::std_sorter{}, &wrapper::value);
+        CHECK( helpers::is_sorted(std::begin(vec), std::end(vec), std::less<>{}, &wrapper::value) );
+    }
+
+    SECTION( "sort with iterators and compare" )
+    {
+        cppsort::sort(std::begin(vec), std::end(vec), cppsort::std_sorter{}, std::greater<>{}, &wrapper::value);
+        CHECK( helpers::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}, &wrapper::value) );
+    }
+}


### PR DESCRIPTION
This branch enhances `sorter_facade` to handle projections even when the underlying *sorter implementation* does not handle them. The new overloads take the projection and bakes them into the passed comparison or in `std::less<>` if no comparison was passed, then passes that new enhanced comparison object to the *sorter implementation*. It allows to give free projections support to sorting algorithms that don't explicitly provide it, and notably to use projections with `std_sorter` and `std_stable_sorter`, even thought these algorithms don't handle them by default.