### PR TITLE
Hide the sorter and adapter abstractions a bit more. Fixes #56.

### DIFF
--- a/benchmarks/bars.py
+++ b/benchmarks/bars.py
@@ -49,7 +49,7 @@ for filename in os.listdir("profiles"):
         "Alternating (16 values)"
     )
 
-    algos = ("heapsort", "introsort", "pdqsort", "vergesort", "timsort", "spreadsort")
+    algos = ("heap_sort", "pdq_sort", "quick_sort", "spread_sort", "std_sort", "verge_sort")
 
     groupnames = distributions
     groupsize = len(algos)

--- a/benchmarks/bench.cpp
+++ b/benchmarks/bench.cpp
@@ -57,12 +57,12 @@ int main()
     };
 
     std::pair<std::string, sort_f<std::vector, int>> sorts[] = {
-        { "heapsort",   cppsort::heap_sorter()      },
-        { "introsort",  cppsort::std_sorter()       },
-        { "pdqsort",    cppsort::pdq_sorter()       },
-        { "vergesort",  cppsort::verge_sorter()     },
-        { "timsort",    cppsort::tim_sorter()       },
-        { "spreadsort", cppsort::spread_sorter()    }
+        { "heap_sort",      cppsort::heap_sort      },
+        { "pdq_sort",       cppsort::pdq_sort       },
+        { "quick_sort",     cppsort::quick_sort     },
+        { "spread_sort",    cppsort::spread_sort    },
+        { "std_sort",       cppsort::std_sort       },
+        { "verge_sort",     cppsort::verge_sort     }
     };
 
     std::size_t sizes[] = { 1'000'000 };

--- a/examples/bubble_sorter.cpp
+++ b/examples/bubble_sorter.cpp
@@ -29,6 +29,7 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/iter_move.h>
 #include <cpp-sort/utility/size.h>
+#include <cpp-sort/utility/static_const.h>
 
 namespace detail
 {
@@ -119,11 +120,16 @@ struct bubble_sorter:
     cppsort::sorter_facade<detail::bubble_sorter_impl>
 {};
 
+namespace
+{
+    constexpr auto&& bubble_sort
+        = cppsort::utility::static_const<bubble_sorter>::value;
+}
+
 #include <algorithm>
 #include <array>
 #include <cassert>
 #include <numeric>
-#include <cpp-sort/sort.h>
 
 int main()
 {
@@ -142,7 +148,7 @@ int main()
     {
         auto to_sort = collection;
         // Bubble sort the collection
-        cppsort::sort(to_sort, bubble_sorter{}, projection);
+        bubble_sort(to_sort, projection);
         // Check that it is sorted in descending order
         assert(std::is_sorted(std::begin(to_sort), std::end(to_sort), std::greater<>{}));
     } while (std::next_permutation(std::begin(collection), std::end(collection)));

--- a/include/cpp-sort/probes/dis.h
+++ b/include/cpp-sort/probes/dis.h
@@ -35,8 +35,8 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
-#include "../detail/static_const.h"
 
 namespace cppsort
 {
@@ -88,7 +88,7 @@ namespace probe
 
     namespace
     {
-        constexpr auto&& dis = cppsort::detail::static_const<
+        constexpr auto&& dis = utility::static_const<
             sorter_facade<detail::dis_impl>
         >::value;
     }

--- a/include/cpp-sort/probes/exc.h
+++ b/include/cpp-sort/probes/exc.h
@@ -37,9 +37,9 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/sorters/pdq_sorter.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/indirect_compare.h"
 #include "../detail/iterator_traits.h"
-#include "../detail/static_const.h"
 
 namespace cppsort
 {
@@ -133,7 +133,7 @@ namespace probe
 
     namespace
     {
-        constexpr auto&& exc = cppsort::detail::static_const<
+        constexpr auto&& exc = utility::static_const<
             sorter_facade<detail::exc_impl>
         >::value;
     }

--- a/include/cpp-sort/probes/ham.h
+++ b/include/cpp-sort/probes/ham.h
@@ -35,9 +35,9 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/sorters/pdq_sorter.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/indirect_compare.h"
 #include "../detail/iterator_traits.h"
-#include "../detail/static_const.h"
 
 namespace cppsort
 {
@@ -102,7 +102,7 @@ namespace probe
 
     namespace
     {
-        constexpr auto&& ham = cppsort::detail::static_const<
+        constexpr auto&& ham = utility::static_const<
             sorter_facade<detail::ham_impl>
         >::value;
     }

--- a/include/cpp-sort/probes/inv.h
+++ b/include/cpp-sort/probes/inv.h
@@ -35,10 +35,10 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/count_inversions.h"
 #include "../detail/indirect_compare.h"
 #include "../detail/iterator_traits.h"
-#include "../detail/static_const.h"
 
 namespace cppsort
 {
@@ -105,7 +105,7 @@ namespace probe
 
     namespace
     {
-        constexpr auto&& inv = cppsort::detail::static_const<
+        constexpr auto&& inv = utility::static_const<
             sorter_facade<detail::inv_impl>
         >::value;
     }

--- a/include/cpp-sort/probes/max.h
+++ b/include/cpp-sort/probes/max.h
@@ -37,9 +37,9 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/sorters/pdq_sorter.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/indirect_compare.h"
 #include "../detail/iterator_traits.h"
-#include "../detail/static_const.h"
 
 namespace cppsort
 {
@@ -103,7 +103,7 @@ namespace probe
 
     namespace
     {
-        constexpr auto&& max = cppsort::detail::static_const<
+        constexpr auto&& max = utility::static_const<
             sorter_facade<detail::max_impl>
         >::value;
     }

--- a/include/cpp-sort/probes/osc.h
+++ b/include/cpp-sort/probes/osc.h
@@ -35,8 +35,8 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
-#include "../detail/static_const.h"
 
 namespace cppsort
 {
@@ -93,7 +93,7 @@ namespace probe
 
     namespace
     {
-        constexpr auto&& osc = cppsort::detail::static_const<
+        constexpr auto&& osc = utility::static_const<
             sorter_facade<detail::osc_impl>
         >::value;
     }

--- a/include/cpp-sort/probes/rem.h
+++ b/include/cpp-sort/probes/rem.h
@@ -35,8 +35,8 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
-#include "../detail/static_const.h"
 
 namespace cppsort
 {
@@ -100,7 +100,7 @@ namespace probe
 
     namespace
     {
-        constexpr auto&& rem = cppsort::detail::static_const<
+        constexpr auto&& rem = utility::static_const<
             sorter_facade<detail::rem_impl>
         >::value;
     }

--- a/include/cpp-sort/probes/runs.h
+++ b/include/cpp-sort/probes/runs.h
@@ -34,8 +34,8 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
-#include "../detail/static_const.h"
 
 namespace cppsort
 {
@@ -89,7 +89,7 @@ namespace probe
 
     namespace
     {
-        constexpr auto&& runs = cppsort::detail::static_const<
+        constexpr auto&& runs = utility::static_const<
             sorter_facade<detail::runs_impl>
         >::value;
     }

--- a/include/cpp-sort/sorters/block_sorter.h
+++ b/include/cpp-sort/sorters/block_sorter.h
@@ -48,7 +48,6 @@ namespace cppsort
         struct block_sorter_impl
         {
             template<
-                typename ActualBufferProvider = BufferProvider,
                 typename RandomAccessIterator,
                 typename Compare = std::less<>,
                 typename Projection = utility::identity,
@@ -68,7 +67,7 @@ namespace cppsort
                     "block_sorter requires at least random-access iterators"
                 );
 
-                block_sort<ActualBufferProvider>(first, last, compare, projection);
+                block_sort<BufferProvider>(first, last, compare, projection);
             }
 
             ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/block_sorter.h
+++ b/include/cpp-sort/sorters/block_sorter.h
@@ -34,6 +34,7 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/buffer.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/block_sort.h"
 #include "../detail/iterator_traits.h"
 
@@ -91,7 +92,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& block_sort
-            = detail::static_const<block_sorter<>>::value;
+            = utility::static_const<block_sorter<>>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/block_sorter.h
+++ b/include/cpp-sort/sorters/block_sorter.h
@@ -85,6 +85,15 @@ namespace cppsort
     struct block_sorter:
         sorter_facade<detail::block_sorter_impl<BufferProvider>>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& block_sort
+            = detail::static_const<block_sorter<>>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_BLOCK_SORTER_H_

--- a/include/cpp-sort/sorters/block_sorter.h
+++ b/include/cpp-sort/sorters/block_sorter.h
@@ -48,6 +48,7 @@ namespace cppsort
         struct block_sorter_impl
         {
             template<
+                typename ActualBufferProvider = BufferProvider,
                 typename RandomAccessIterator,
                 typename Compare = std::less<>,
                 typename Projection = utility::identity,
@@ -67,7 +68,7 @@ namespace cppsort
                     "block_sorter requires at least random-access iterators"
                 );
 
-                block_sort<BufferProvider>(first, last, compare, projection);
+                block_sort<ActualBufferProvider>(first, last, compare, projection);
             }
 
             ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/grail_sorter.h
+++ b/include/cpp-sort/sorters/grail_sorter.h
@@ -47,6 +47,7 @@ namespace cppsort
         struct grail_sorter_impl
         {
             template<
+                typename ActualBufferProvider = BufferProvider,
                 typename RandomAccessIterator,
                 typename Compare = std::less<>,
                 typename Projection = utility::identity,
@@ -66,7 +67,7 @@ namespace cppsort
                     "grail_sorter requires at least random-access iterators"
                 );
 
-                grail_sort<BufferProvider>(first, last, compare, projection);
+                grail_sort<ActualBufferProvider>(first, last, compare, projection);
             }
 
             ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/grail_sorter.h
+++ b/include/cpp-sort/sorters/grail_sorter.h
@@ -34,6 +34,7 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/buffer.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/grail_sort.h"
 
 namespace cppsort
@@ -90,7 +91,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& grail_sort
-            = detail::static_const<grail_sorter<>>::value;
+            = utility::static_const<grail_sorter<>>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/grail_sorter.h
+++ b/include/cpp-sort/sorters/grail_sorter.h
@@ -47,7 +47,6 @@ namespace cppsort
         struct grail_sorter_impl
         {
             template<
-                typename ActualBufferProvider = BufferProvider,
                 typename RandomAccessIterator,
                 typename Compare = std::less<>,
                 typename Projection = utility::identity,
@@ -67,7 +66,7 @@ namespace cppsort
                     "grail_sorter requires at least random-access iterators"
                 );
 
-                grail_sort<ActualBufferProvider>(first, last, compare, projection);
+                grail_sort<BufferProvider>(first, last, compare, projection);
             }
 
             ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/grail_sorter.h
+++ b/include/cpp-sort/sorters/grail_sorter.h
@@ -84,6 +84,15 @@ namespace cppsort
     struct grail_sorter:
         sorter_facade<detail::grail_sorter_impl<BufferProvider>>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& grail_sort
+            = detail::static_const<grail_sorter<>>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_GRAIL_SORTER_H_

--- a/include/cpp-sort/sorters/heap_sorter.h
+++ b/include/cpp-sort/sorters/heap_sorter.h
@@ -33,6 +33,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/heapsort.h"
 #include "../detail/iterator_traits.h"
 
@@ -86,7 +87,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& heap_sort
-            = detail::static_const<heap_sorter>::value;
+            = utility::static_const<heap_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/heap_sorter.h
+++ b/include/cpp-sort/sorters/heap_sorter.h
@@ -79,6 +79,15 @@ namespace cppsort
     struct heap_sorter:
         sorter_facade<detail::heap_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& heap_sort
+            = detail::static_const<heap_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_HEAP_SORTER_H_

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -79,6 +79,15 @@ namespace cppsort
     struct insertion_sorter:
         sorter_facade<detail::insertion_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& insertion_sort
+            = detail::static_const<insertion_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_INSERTION_SORTER_H_

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -33,6 +33,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/insertion_sort.h"
 #include "../detail/iterator_traits.h"
 
@@ -86,7 +87,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& insertion_sort
-            = detail::static_const<insertion_sorter>::value;
+            = utility::static_const<insertion_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/merge_insertion_sorter.h
+++ b/include/cpp-sort/sorters/merge_insertion_sorter.h
@@ -33,6 +33,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 #include "../detail/merge_insertion_sort.h"
 
@@ -86,7 +87,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& merge_insertion_sort
-            = detail::static_const<merge_insertion_sorter>::value;
+            = utility::static_const<merge_insertion_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/merge_insertion_sorter.h
+++ b/include/cpp-sort/sorters/merge_insertion_sorter.h
@@ -79,6 +79,15 @@ namespace cppsort
     struct merge_insertion_sorter:
         sorter_facade<detail::merge_insertion_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& merge_insertion_sort
+            = detail::static_const<merge_insertion_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_MERGE_INSERTION_SORTER_H_

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -106,6 +106,15 @@ namespace cppsort
     struct merge_sorter:
         sorter_facade<detail::merge_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& merge_sort
+            = detail::static_const<merge_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_MERGE_SORTER_H_

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -34,6 +34,7 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
 #include <cpp-sort/utility/size.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 #include "../detail/merge_sort.h"
 
@@ -113,7 +114,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& merge_sort
-            = detail::static_const<merge_sorter>::value;
+            = utility::static_const<merge_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/pdq_sorter.h
+++ b/include/cpp-sort/sorters/pdq_sorter.h
@@ -33,6 +33,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 #include "../detail/pdqsort.h"
 
@@ -86,7 +87,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& pdq_sort
-            = detail::static_const<pdq_sorter>::value;
+            = utility::static_const<pdq_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/pdq_sorter.h
+++ b/include/cpp-sort/sorters/pdq_sorter.h
@@ -79,6 +79,15 @@ namespace cppsort
     struct pdq_sorter:
         sorter_facade<detail::pdq_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& pdq_sort
+            = detail::static_const<pdq_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_PDQ_SORTER_H_

--- a/include/cpp-sort/sorters/poplar_sorter.h
+++ b/include/cpp-sort/sorters/poplar_sorter.h
@@ -79,6 +79,15 @@ namespace cppsort
     struct poplar_sorter:
         sorter_facade<detail::poplar_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& poplar_sort
+            = detail::static_const<poplar_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_POPLAR_SORTER_H_

--- a/include/cpp-sort/sorters/poplar_sorter.h
+++ b/include/cpp-sort/sorters/poplar_sorter.h
@@ -33,6 +33,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 #include "../detail/poplar_sort.h"
 
@@ -86,7 +87,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& poplar_sort
-            = detail::static_const<poplar_sorter>::value;
+            = utility::static_const<poplar_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/quick_sorter.h
+++ b/include/cpp-sort/sorters/quick_sorter.h
@@ -106,6 +106,15 @@ namespace cppsort
     struct quick_sorter:
         sorter_facade<detail::quick_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& quick_sort
+            = detail::static_const<quick_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_QUICK_SORTER_H_

--- a/include/cpp-sort/sorters/quick_sorter.h
+++ b/include/cpp-sort/sorters/quick_sorter.h
@@ -34,6 +34,7 @@
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
 #include <cpp-sort/utility/size.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 #include "../detail/quicksort.h"
 
@@ -113,7 +114,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& quick_sort
-            = detail::static_const<quick_sorter>::value;
+            = utility::static_const<quick_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/selection_sorter.h
+++ b/include/cpp-sort/sorters/selection_sorter.h
@@ -79,6 +79,15 @@ namespace cppsort
     struct selection_sorter:
         sorter_facade<detail::selection_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& selection_sort
+            = detail::static_const<selection_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_SELECTION_SORTER_H_

--- a/include/cpp-sort/sorters/selection_sorter.h
+++ b/include/cpp-sort/sorters/selection_sorter.h
@@ -33,6 +33,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 #include "../detail/selection_sort.h"
 
@@ -86,7 +87,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& selection_sort
-            = detail::static_const<selection_sorter>::value;
+            = utility::static_const<selection_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/smooth_sorter.h
+++ b/include/cpp-sort/sorters/smooth_sorter.h
@@ -33,6 +33,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 #include "../detail/smoothsort.h"
 
@@ -86,7 +87,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& smooth_sort
-            = detail::static_const<smooth_sorter>::value;
+            = utility::static_const<smooth_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/smooth_sorter.h
+++ b/include/cpp-sort/sorters/smooth_sorter.h
@@ -79,6 +79,15 @@ namespace cppsort
     struct smooth_sorter:
         sorter_facade<detail::smooth_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& smooth_sort
+            = detail::static_const<smooth_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_SMOOTH_SORTER_H_

--- a/include/cpp-sort/sorters/spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter.h
@@ -34,6 +34,9 @@
 
 namespace cppsort
 {
+    ////////////////////////////////////////////////////////////
+    // Sorter
+
     struct spread_sorter:
         hybrid_adapter<
             integer_spread_sorter,
@@ -41,6 +44,15 @@ namespace cppsort
             string_spread_sorter
         >
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& spread_sort
+            = detail::static_const<spread_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_SPREAD_SORTER_H_

--- a/include/cpp-sort/sorters/spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter.h
@@ -31,6 +31,7 @@
 #include <cpp-sort/sorters/spread_sorter/float_spread_sorter.h>
 #include <cpp-sort/sorters/spread_sorter/integer_spread_sorter.h>
 #include <cpp-sort/sorters/spread_sorter/string_spread_sorter.h>
+#include <cpp-sort/utility/static_const.h>
 
 namespace cppsort
 {
@@ -51,7 +52,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& spread_sort
-            = detail::static_const<spread_sorter>::value;
+            = utility::static_const<spread_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/spread_sorter/float_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/float_spread_sorter.h
@@ -68,6 +68,15 @@ namespace cppsort
     struct float_spread_sorter:
         sorter_facade<detail::float_spread_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& float_spread_sort
+            = detail::static_const<float_spread_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_SPREAD_SORTER_FLOAT_SPREAD_SORTER_H_

--- a/include/cpp-sort/sorters/spread_sorter/float_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/float_spread_sorter.h
@@ -32,6 +32,7 @@
 #include <limits>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../../detail/iterator_traits.h"
 #include "../../detail/spreadsort/float_sort.h"
 
@@ -75,7 +76,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& float_spread_sort
-            = detail::static_const<float_spread_sorter>::value;
+            = utility::static_const<float_spread_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/spread_sorter/integer_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/integer_spread_sorter.h
@@ -62,6 +62,15 @@ namespace cppsort
     struct integer_spread_sorter:
         sorter_facade<detail::integer_spread_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& integer_spread_sort
+            = detail::static_const<integer_spread_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_SPREAD_SORTER_INTEGER_SPREAD_SORTER_H_

--- a/include/cpp-sort/sorters/spread_sorter/integer_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/integer_spread_sorter.h
@@ -30,6 +30,7 @@
 #include <iterator>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../../detail/iterator_traits.h"
 #include "../../detail/spreadsort/integer_sort.h"
 
@@ -69,7 +70,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& integer_spread_sort
-            = detail::static_const<integer_spread_sorter>::value;
+            = utility::static_const<integer_spread_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/spread_sorter/string_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/string_spread_sorter.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../../detail/iterator_traits.h"
 #include "../../detail/spreadsort/string_sort.h"
 
@@ -111,7 +112,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& string_spread_sort
-            = detail::static_const<string_spread_sorter>::value;
+            = utility::static_const<string_spread_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/spread_sorter/string_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/string_spread_sorter.h
@@ -104,6 +104,15 @@ namespace cppsort
     struct string_spread_sorter:
         sorter_facade<detail::string_spread_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& string_spread_sort
+            = detail::static_const<string_spread_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_SPREAD_SORTER_STRING_SPREAD_SORTER_H_

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -120,6 +120,15 @@ namespace cppsort
     struct stable_adapter<std_sorter>:
         sorter_facade<detail::std_stable_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& std_sort
+            = detail::static_const<std_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_STD_SORTER_H_

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -34,6 +34,7 @@
 #include <cpp-sort/fwd.h>
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 
 namespace cppsort
@@ -127,7 +128,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& std_sort
-            = detail::static_const<std_sorter>::value;
+            = utility::static_const<std_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -79,6 +79,15 @@ namespace cppsort
     struct tim_sorter:
         sorter_facade<detail::tim_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& tim_sort
+            = detail::static_const<tim_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_TIM_SORTER_H_

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -33,6 +33,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 #include "../detail/timsort.h"
 
@@ -86,7 +87,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& tim_sort
-            = detail::static_const<tim_sorter>::value;
+            = utility::static_const<tim_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/sorters/verge_sorter.h
+++ b/include/cpp-sort/sorters/verge_sorter.h
@@ -79,6 +79,15 @@ namespace cppsort
     struct verge_sorter:
         sorter_facade<detail::verge_sorter_impl>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& verge_sort
+            = detail::static_const<verge_sorter>::value;
+    }
 }
 
 #endif // CPPSORT_SORTERS_VERGE_SORTER_H_

--- a/include/cpp-sort/sorters/verge_sorter.h
+++ b/include/cpp-sort/sorters/verge_sorter.h
@@ -33,6 +33,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 #include "../detail/vergesort.h"
 
@@ -86,7 +87,7 @@ namespace cppsort
     namespace
     {
         constexpr auto&& verge_sort
-            = detail::static_const<verge_sorter>::value;
+            = utility::static_const<verge_sorter>::value;
     }
 }
 

--- a/include/cpp-sort/stable_sort.h
+++ b/include/cpp-sort/stable_sort.h
@@ -1,0 +1,192 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_STABLE_SORT_H_
+#define CPPSORT_STABLE_SORT_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <type_traits>
+#include <cpp-sort/adapters/stable_adapter.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/sorters/default_sorter.h>
+
+namespace cppsort
+{
+    ////////////////////////////////////////////////////////////
+    // With default_sorter
+
+    template<typename Iterable>
+    auto stable_sort(Iterable& iterable)
+        -> void
+    {
+        stable_adapter<default_sorter>{}(iterable);
+    }
+
+    template<
+        typename Iterable,
+        typename Compare,
+        typename = std::enable_if_t<not is_sorter<Compare, Iterable>>
+    >
+    auto stable_sort(Iterable& iterable, Compare compare)
+        -> void
+    {
+        stable_adapter<default_sorter>{}(iterable, compare);
+    }
+
+    template<
+        typename Iterable,
+        typename Compare,
+        typename Projection,
+        typename = std::enable_if_t<
+            not is_comparison_sorter<Compare, Iterable, Projection> &&
+            not is_projection_sorter<Compare, Iterable, Projection>
+        >
+    >
+    auto stable_sort(Iterable& iterable, Compare compare, Projection projection)
+        -> void
+    {
+        stable_adapter<default_sorter>{}(iterable, compare, projection);
+    }
+
+    template<typename Iterator>
+    auto stable_sort(Iterator first, Iterator last)
+        -> void
+    {
+        stable_adapter<default_sorter>{}(first, last);
+    }
+
+    template<
+        typename Iterator,
+        typename Compare,
+        typename = std::enable_if_t<not is_sorter_iterator<Compare, Iterator>>
+    >
+    auto stable_sort(Iterator first, Iterator last, Compare compare)
+        -> void
+    {
+        stable_adapter<default_sorter>{}(first, last, compare);
+    }
+
+    template<
+        typename Iterator,
+        typename Compare,
+        typename Projection,
+        typename = std::enable_if_t<
+            not is_comparison_sorter_iterator<Compare, Iterator, Projection> &&
+            not is_projection_sorter_iterator<Compare, Iterator, Projection>
+        >
+    >
+    auto stable_sort(Iterator first, Iterator last, Compare compare, Projection projection)
+        -> void
+    {
+        return stable_adapter<default_sorter>{}(first, last, compare, projection);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // With a given sorter
+
+    template<
+        typename Iterable,
+        typename Sorter,
+        typename = std::enable_if_t<is_sorter<
+            stable_adapter<Sorter>, Iterable
+        >>
+    >
+    auto stable_sort(Iterable& iterable, const Sorter&)
+        -> decltype(auto)
+    {
+        return stable_adapter<Sorter>{}(iterable);
+    }
+
+    template<
+        typename Iterable,
+        typename Sorter,
+        typename Func,
+        typename = std::enable_if_t<
+            is_comparison_sorter<stable_adapter<Sorter>, Iterable, Func> ||
+            is_projection_sorter<stable_adapter<Sorter>, Iterable, Func>
+        >
+    >
+    auto stable_sort(Iterable& iterable, const Sorter&, Func func)
+        -> decltype(auto)
+    {
+        return stable_adapter<Sorter>{}(iterable, func);
+    }
+
+    template<
+        typename Iterable,
+        typename Sorter,
+        typename Compare,
+        typename Projection
+    >
+    auto stable_sort(Iterable& iterable, const Sorter&,
+                     Compare compare, Projection projection)
+        -> decltype(auto)
+    {
+        return stable_adapter<Sorter>{}(iterable, compare, projection);
+    }
+
+    template<
+        typename Iterator,
+        typename Sorter,
+        typename = std::enable_if_t<is_sorter_iterator<
+            stable_adapter<Sorter>, Iterator
+        >>
+    >
+    auto stable_sort(Iterator first, Iterator last, const Sorter&)
+        -> decltype(auto)
+    {
+        return stable_adapter<Sorter>{}(first, last);
+    }
+
+    template<
+        typename Iterator,
+        typename Sorter,
+        typename Func,
+        typename = std::enable_if_t<
+            is_comparison_sorter_iterator<stable_adapter<Sorter>, Iterator, Func> ||
+            is_projection_sorter_iterator<stable_adapter<Sorter>, Iterator, Func>
+        >
+    >
+    auto stable_sort(Iterator first, Iterator last, const Sorter&, Func func)
+        -> decltype(auto)
+    {
+        return stable_adapter<Sorter>{}(first, last, func);
+    }
+
+    template<
+        typename Iterator,
+        typename Sorter,
+        typename Compare,
+        typename Projection
+    >
+    auto stable_sort(Iterator first, Iterator last, const Sorter&,
+                     Compare compare, Projection projection)
+        -> decltype(auto)
+    {
+        return stable_adapter<Sorter>{}(first, last, compare, projection);
+    }
+}
+
+#endif // CPPSORT_STABLE_SORT_H_

--- a/include/cpp-sort/utility/as_function.h
+++ b/include/cpp-sort/utility/as_function.h
@@ -19,7 +19,7 @@
 #include <functional>
 #include <type_traits>
 #include <utility>
-#include "../detail/static_const.h"
+#include <cpp-sort/utility/static_const.h>
 
 namespace cppsort
 {
@@ -79,7 +79,7 @@ namespace utility
 
     namespace
     {
-        constexpr auto&& as_function = cppsort::detail::static_const<
+        constexpr auto&& as_function = static_const<
             detail::as_function_fn
         >::value;
     }

--- a/include/cpp-sort/utility/static_const.h
+++ b/include/cpp-sort/utility/static_const.h
@@ -11,22 +11,21 @@
 // Project home: https://github.com/ericniebler/range-v3
 //
 
-#ifndef CPPSORT_DETAIL_STATIC_CONST_H_
-#define CPPSORT_DETAIL_STATIC_CONST_H_
+#ifndef CPPSORT_UTILITY_STATIC_CONST_H_
+#define CPPSORT_UTILITY_STATIC_CONST_H_
 
 namespace cppsort
 {
-    namespace detail
+namespace utility
+{
+    template<typename T>
+    struct static_const
     {
-        template<typename T>
-        struct static_const
-        {
-            static constexpr T value {};
-        };
+        static constexpr T value{};
+    };
 
-        template<typename T>
-        constexpr T static_const<T>::value;
-    }
-}
+    template<typename T>
+    constexpr T static_const<T>::value;
+}}
 
-#endif // CPPSORT_DETAIL_STATIC_CONST_H_
+#endif // CPPSORT_UTILITY_STATIC_CONST_H_

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(
     cpp-sort-testsuite
 
     main.cpp
+    every_instantiated_sorter.cpp
     every_sorter.cpp
     rebind_iterator_category.cpp
     sorter_facade.cpp

--- a/testsuite/adapters/stable_adapter_every_sorter.cpp
+++ b/testsuite/adapters/stable_adapter_every_sorter.cpp
@@ -28,9 +28,8 @@
 #include <random>
 #include <vector>
 #include <catch.hpp>
-#include <cpp-sort/adapters/stable_adapter.h>
-#include <cpp-sort/sort.h>
 #include <cpp-sort/sorters.h>
+#include <cpp-sort/stable_sort.h>
 #include <cpp-sort/utility/buffer.h>
 
 namespace
@@ -75,110 +74,106 @@ TEST_CASE( "every sorter with stable adapter",
 
     SECTION( "block_sorter" )
     {
-        using namespace cppsort;
-
-        using sorter = stable_adapter<block_sorter<
-            utility::fixed_buffer<0>
-        >>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::block_sorter<cppsort::utility::fixed_buffer<0>>;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "default_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::default_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::default_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "grail_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::grail_sorter<>>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::grail_sorter<>;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "heap_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::heap_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::heap_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "insertion_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::insertion_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::insertion_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "merge_insertion_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::merge_insertion_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::merge_insertion_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "merge_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::merge_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::merge_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "pdq_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::pdq_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::pdq_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "poplar_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::poplar_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::poplar_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "quick_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::quick_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::quick_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "selection_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::selection_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::selection_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "smooth_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::smooth_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::smooth_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "std_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::std_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::std_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "tim_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::tim_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::tim_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 
     SECTION( "verge_sorter" )
     {
-        using sorter = cppsort::stable_adapter<cppsort::verge_sorter>;
-        cppsort::sort(collection, sorter{}, &wrapper::value);
+        using sorter = cppsort::verge_sorter;
+        cppsort::stable_sort(collection, sorter{}, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 }

--- a/testsuite/every_instantiated_sorter.cpp
+++ b/testsuite/every_instantiated_sorter.cpp
@@ -23,10 +23,10 @@
  */
 #include <algorithm>
 #include <ctime>
-#include <deque>
 #include <iterator>
 #include <numeric>
 #include <random>
+#include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sorters.h>
 
@@ -40,7 +40,7 @@ TEST_CASE( "test every instantiated sorter", "[sorters]" )
     // Only default_sorter doesn't have a standard instance
     // since it is already used by default by cppsort::sort
 
-    std::deque<double> collection(35);
+    std::vector<double> collection(35);
     std::iota(std::begin(collection), std::end(collection), -47.0);
     std::mt19937 engine(std::time(nullptr));
     std::shuffle(std::begin(collection), std::end(collection), engine);

--- a/testsuite/every_instantiated_sorter.cpp
+++ b/testsuite/every_instantiated_sorter.cpp
@@ -1,0 +1,137 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <ctime>
+#include <deque>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <catch.hpp>
+#include <cpp-sort/sorters.h>
+
+TEST_CASE( "test every instantiated sorter", "[sorters]" )
+{
+    // Sorters are great, but if we can hide the abstraction
+    // under instantiated sorters that look like regular
+    // functions, then it's even better, but we need to test
+    // them to, just to be sure
+    //
+    // Only default_sorter doesn't have a standard instance
+    // since it is already used by default by cppsort::sort
+
+    std::deque<double> collection(35);
+    std::iota(std::begin(collection), std::end(collection), -47.0);
+    std::mt19937 engine(std::time(nullptr));
+    std::shuffle(std::begin(collection), std::end(collection), engine);
+
+    SECTION( "block_sort" )
+    {
+        cppsort::block_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        cppsort::grail_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::heap_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "insertion_sorter" )
+    {
+        cppsort::insertion_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_insertion_sorter" )
+    {
+        cppsort::merge_insertion_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::merge_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::pdq_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::poplar_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::quick_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "selection_sorter" )
+    {
+        cppsort::selection_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::smooth_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::spread_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::std_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::tim_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::verge_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}


### PR DESCRIPTION
The sorter abstraction is useful, but most of the time people only need function-like sorting algorithms and nothing more. This pull request implements several changes, principally meant to hide the abstractions as long as they are unneeded:
* Add `cppsort::stable_sort` to match the standard library's `std::stable_sort`. It simply uses `stable_adapter` on the passed sorter or on `default_sorter` if no sorter was given, and uses the result to sort the given collection.
* Instantiate every regular sorter except `default_sorter`, which is only meant to be used as a fallback for `cppsort::sort` and `cppsort::stable_sort`.
* Move `static_const` into `utility::` since sorter implementers might need it to instantiate their own sorters.

Sorter adapters and fixed-sized sorters are already advanced abstractions, so nothing is done to hide them more, save for `cppsort::stable_sort`.