### PR TITLE
Handle projection-only type-specific sorters. Fixes #68.

### DIFF
--- a/include/cpp-sort/detail/associate_iterator.h
+++ b/include/cpp-sort/detail/associate_iterator.h
@@ -152,6 +152,9 @@ namespace detail
         {
             return value;
         }
+
+        // Silence GCC -Winline warning
+        ~associated_value() noexcept {}
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/detail/iterator_traits.h
+++ b/include/cpp-sort/detail/iterator_traits.h
@@ -28,6 +28,8 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <iterator>
+#include <type_traits>
+#include <utility>
 #include <cpp-sort/utility/iter_move.h>
 
 namespace cppsort
@@ -61,6 +63,13 @@ namespace detail
 
     template<typename Iterator>
     using rvalue_reference_t = utility::rvalue_reference_t<Iterator>;
+
+    //
+    // Handy addition from time to time
+    //
+
+    template<typename Iterator, typename Projection>
+    using projected_t = std::decay_t<std::result_of_t<Projection(decltype(*std::declval<Iterator&>()))>>;
 }}
 
 #endif // CPPSORT_DETAIL_ITERATOR_TRAITS_H_

--- a/include/cpp-sort/detail/spreadsort/detail/float_sort.h
+++ b/include/cpp-sort/detail/spreadsort/detail/float_sort.h
@@ -10,8 +10,6 @@
 /*
 Some improvements suggested by:
 Phil Endecott and Frank Gennari
-float_mem_cast fix provided by:
-Scott McMurray
 */
 
 // Modified in 2015-2016 by Morwenn for inclusion into cpp-sort
@@ -28,9 +26,10 @@ Scott McMurray
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <type_traits>
 #include <vector>
-#include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/as_function.h>
 #include "common.h"
 #include "constants.h"
 #include "integer_sort.h"
@@ -43,87 +42,47 @@ namespace detail
 {
 namespace spreadsort
 {
-  namespace detail {
+namespace detail
+{
     //Casts a RandomAccessIter to the specified integer type
-    template<class Cast_type, class RandomAccessIter>
-    auto cast_float_iter(const RandomAccessIter & floatiter)
+    template<typename Cast_type, typename RandomAccessIter, typename Projection>
+    auto cast_float_iter(const RandomAccessIter & floatiter, Projection projection)
         -> Cast_type
     {
-      using Data_type = value_type_t<RandomAccessIter>;
+      using Data_type = projected_t<RandomAccessIter, Projection>;
+      auto&& proj = utility::as_function(projection);
+
       //Only cast IEEE floating-point numbers, and only to same-sized integers
       static_assert(sizeof(Cast_type) == sizeof(Data_type), "");
       static_assert(std::numeric_limits<Data_type>::is_iec559, "");
       static_assert(std::numeric_limits<Cast_type>::is_integer, "");
       Cast_type result;
-      std::memcpy(&result, &(*floatiter), sizeof(Data_type));
+      std::memcpy(std::addressof(result),
+                  std::addressof(proj(*floatiter)),
+                  sizeof(Data_type));
       return result;
     }
 
-    // Return true if the list is sorted.  Otherwise, find the minimum and
-    // maximum.  Values are Right_shifted 0 bits before comparison.
-    template<class RandomAccessIter, class Div_type, class Right_shift>
-    auto is_sorted_or_find_extremes(RandomAccessIter current, RandomAccessIter last,
-                                    Div_type & max, Div_type & min, Right_shift rshift)
-        -> bool
-    {
-      min = max = rshift(*current, 0);
-      RandomAccessIter prev = current;
-      bool sorted = true;
-      while (++current < last) {
-        Div_type value = rshift(*current, 0);
-        sorted &= *current >= *prev;
-        prev = current;
-        if (max < value)
-          max = value;
-        else if (value < min)
-          min = value;
-      }
-      return sorted;
-    }
-
-    // Return true if the list is sorted.  Otherwise, find the minimum and
-    // maximum.  Uses comp to check if the data is already sorted.
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Compare>
-    auto is_sorted_or_find_extremes(RandomAccessIter current, RandomAccessIter last,
-                                    Div_type & max, Div_type & min,
-                                    Right_shift rshift, Compare comp)
-        -> bool
-    {
-      min = max = rshift(*current, 0);
-      RandomAccessIter prev = current;
-      bool sorted = true;
-      while (++current < last) {
-        Div_type value = rshift(*current, 0);
-        sorted &= !comp(*current, *prev);
-        prev = current;
-        if (max < value)
-          max = value;
-        else if (value < min)
-          min = value;
-      }
-      return sorted;
-    }
-
     //Specialized swap loops for floating-point casting
-    template<class RandomAccessIter, class Div_type>
+    template<typename RandomAccessIter, typename Div_type, typename Projection>
     auto inner_float_swap_loop(RandomAccessIter * bins,
                                const RandomAccessIter & nextbinstart, unsigned ii,
-                               const unsigned log_divisor, const Div_type div_min)
+                               const unsigned log_divisor, const Div_type div_min,
+                               Projection projection)
         -> void
     {
       RandomAccessIter * local_bin = bins + ii;
       for (RandomAccessIter current = *local_bin; current < nextbinstart;
           ++current) {
         for (RandomAccessIter * target_bin =
-            (bins + ((cast_float_iter<Div_type, RandomAccessIter>(current) >>
+            (bins + ((cast_float_iter<Div_type>(current, projection) >>
                       log_divisor) - div_min));  target_bin != local_bin;
-          target_bin = bins + ((cast_float_iter<Div_type, RandomAccessIter>
-                               (current) >> log_divisor) - div_min)) {
+          target_bin = bins + ((cast_float_iter<Div_type>(current, projection) >> log_divisor)
+                            - div_min)) {
           value_type_t<RandomAccessIter> tmp;
           RandomAccessIter b = (*target_bin)++;
-          RandomAccessIter * b_bin = bins + ((cast_float_iter<Div_type,
-                              RandomAccessIter>(b) >> log_divisor) - div_min);
+          RandomAccessIter * b_bin = bins + ((cast_float_iter<Div_type>(b, projection) >> log_divisor)
+                                          - div_min);
           //Three-way swap; if the item to be swapped doesn't belong in the
           //current bin, swap it to where it belongs
           if (b_bin != local_bin) {
@@ -140,31 +99,35 @@ namespace spreadsort
       *local_bin = nextbinstart;
     }
 
-    template<class RandomAccessIter, class Div_type>
+    template<typename RandomAccessIter, typename Div_type, typename Projection>
     auto float_swap_loop(RandomAccessIter * bins,
                          RandomAccessIter & nextbinstart, unsigned ii,
                          const std::size_t *bin_sizes,
-                         const unsigned log_divisor, const Div_type div_min)
+                         const unsigned log_divisor, const Div_type div_min,
+                         Projection projection)
         -> void
     {
       nextbinstart += bin_sizes[ii];
       inner_float_swap_loop<RandomAccessIter, Div_type>
-        (bins, nextbinstart, ii, log_divisor, div_min);
+        (bins, nextbinstart, ii, log_divisor, div_min, projection);
     }
 
     // Return true if the list is sorted.  Otherwise, find the minimum and
     // maximum.  Values are cast to Cast_type before comparison.
-    template<class RandomAccessIter, class Cast_type>
+    template<typename RandomAccessIter, typename Cast_type, typename Projection>
     auto is_sorted_or_find_extremes(RandomAccessIter current, RandomAccessIter last,
-                                    Cast_type & max, Cast_type & min)
+                                    Cast_type & max, Cast_type & min,
+                                    Projection projection)
         -> bool
     {
-      min = max = cast_float_iter<Cast_type, RandomAccessIter>(current);
+      auto&& proj = utility::as_function(projection);
+
+      min = max = cast_float_iter<Cast_type>(current, projection);
       RandomAccessIter prev = current;
       bool sorted = true;
       while (++current < last) {
-        Cast_type value = cast_float_iter<Cast_type, RandomAccessIter>(current);
-        sorted &= *current >= *prev;
+        Cast_type value = cast_float_iter<Cast_type>(current, projection);
+        sorted &= proj(*current) >= proj(*prev);
         prev = current;
         if (max < value)
           max = value;
@@ -175,15 +138,16 @@ namespace spreadsort
     }
 
     //Special-case sorting of positive floats with casting
-    template<class RandomAccessIter, class Div_type, class Size_type>
+    template<typename RandomAccessIter, typename Div_type,
+             typename Size_type, typename Projection>
     auto positive_float_sort_rec(RandomAccessIter first, RandomAccessIter last,
                                  std::vector<RandomAccessIter> &bin_cache, unsigned cache_offset,
-                                 std::size_t *bin_sizes)
+                                 std::size_t *bin_sizes, Projection projection)
         -> void
     {
       Div_type max, min;
-      if (is_sorted_or_find_extremes<RandomAccessIter, Div_type>(first, last,
-                                                                 max, min))
+      if (is_sorted_or_find_extremes<RandomAccessIter, Div_type>(
+        first, last, max, min, projection))
         return;
 
       unsigned log_divisor = get_log_divisor<float_log_mean_bin_size>(
@@ -197,8 +161,8 @@ namespace spreadsort
 
       //Calculating the size of each bin
       for (RandomAccessIter current = first; current != last;)
-        bin_sizes[unsigned((cast_float_iter<Div_type, RandomAccessIter>(
-            current++) >> log_divisor) - div_min)]++;
+        bin_sizes[unsigned((cast_float_iter<Div_type>(
+            current++, projection) >> log_divisor) - div_min)]++;
       bins[0] = first;
       for (unsigned u = 0; u < bin_count - 1; u++)
         bins[u + 1] = bins[u] + bin_sizes[u];
@@ -208,7 +172,7 @@ namespace spreadsort
       RandomAccessIter nextbinstart = first;
       for (unsigned u = 0; u < bin_count - 1; ++u)
         float_swap_loop<RandomAccessIter, Div_type>
-          (bins, nextbinstart, u, bin_sizes, log_divisor, div_min);
+          (bins, nextbinstart, u, bin_sizes, log_divisor, div_min, projection);
       bins[bin_count - 1] = last;
 
       //Return if we've completed bucketsorting
@@ -226,24 +190,26 @@ namespace spreadsort
         if (count < 2)
           continue;
         if (count < max_count)
-          pdqsort(lastPos, bin_cache[u], std::less<>{}, utility::identity{});
+          pdqsort(lastPos, bin_cache[u], std::less<>{}, projection);
         else
           positive_float_sort_rec<RandomAccessIter, Div_type, Size_type>
-            (lastPos, bin_cache[u], bin_cache, cache_end, bin_sizes);
+            (lastPos, bin_cache[u], bin_cache, cache_end, bin_sizes, projection);
       }
     }
 
     //Sorting negative floats
     //Bins are iterated in reverse because max_neg_float = min_neg_int
-    template<class RandomAccessIter, class Div_type, class Size_type>
+    template<typename RandomAccessIter, typename Div_type,
+             typename Size_type, typename Projection>
     auto negative_float_sort_rec(RandomAccessIter first, RandomAccessIter last,
                                  std::vector<RandomAccessIter> &bin_cache,
-                                 unsigned cache_offset, std::size_t *bin_sizes)
+                                 unsigned cache_offset, std::size_t *bin_sizes,
+                                 Projection projection)
         -> void
     {
       Div_type max, min;
-      if (is_sorted_or_find_extremes<RandomAccessIter, Div_type>(first, last,
-                                                                 max, min))
+      if (is_sorted_or_find_extremes<RandomAccessIter, Div_type>(
+        first, last, max, min, projection))
         return;
 
       unsigned log_divisor = get_log_divisor<float_log_mean_bin_size>(
@@ -257,8 +223,8 @@ namespace spreadsort
 
       //Calculating the size of each bin
       for (RandomAccessIter current = first; current != last;)
-        bin_sizes[unsigned((cast_float_iter<Div_type, RandomAccessIter>(
-            current++) >> log_divisor) - div_min)]++;
+        bin_sizes[unsigned((cast_float_iter<Div_type>(
+            current++, projection) >> log_divisor) - div_min)]++;
       bins[bin_count - 1] = first;
       for (int ii = bin_count - 2; ii >= 0; --ii)
         bins[ii] = bins[ii + 1] + bin_sizes[ii + 1];
@@ -268,7 +234,7 @@ namespace spreadsort
       //The last bin will always have the correct elements in it
       for (int ii = bin_count - 1; ii > 0; --ii)
         float_swap_loop<RandomAccessIter, Div_type>
-          (bins, nextbinstart, ii, bin_sizes, log_divisor, div_min);
+          (bins, nextbinstart, ii, bin_sizes, log_divisor, div_min, projection);
       //Update the end position because we don't process the last bin
       bin_cache[cache_offset] = last;
 
@@ -287,142 +253,24 @@ namespace spreadsort
         if (count < 2)
           continue;
         if (count < max_count)
-          pdqsort(lastPos, bin_cache[ii], std::less<>{}, utility::identity{});
+          pdqsort(lastPos, bin_cache[ii], std::less<>{}, projection);
         else
           negative_float_sort_rec<RandomAccessIter, Div_type, Size_type>
-            (lastPos, bin_cache[ii], bin_cache, cache_end, bin_sizes);
-      }
-    }
-
-    //Sorting negative floats
-    //Bins are iterated in reverse order because max_neg_float = min_neg_int
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Size_type>
-    auto negative_float_sort_rec(RandomAccessIter first, RandomAccessIter last,
-                                 std::vector<RandomAccessIter> &bin_cache, unsigned cache_offset,
-                                 std::size_t *bin_sizes, Right_shift rshift)
-        -> void
-    {
-      Div_type max, min;
-      if (is_sorted_or_find_extremes(first, last, max, min, rshift))
-        return;
-      unsigned log_divisor = get_log_divisor<float_log_mean_bin_size>(
-          last - first, rough_log_2_size(Size_type(max - min)));
-      Div_type div_min = min >> log_divisor;
-      Div_type div_max = max >> log_divisor;
-      unsigned bin_count = unsigned(div_max - div_min) + 1;
-      unsigned cache_end;
-      RandomAccessIter * bins = size_bins(bin_sizes, bin_cache, cache_offset,
-                                          cache_end, bin_count);
-
-      //Calculating the size of each bin
-      for (RandomAccessIter current = first; current != last;)
-        bin_sizes[unsigned(rshift(*(current++), log_divisor) - div_min)]++;
-      bins[bin_count - 1] = first;
-      for (int ii = bin_count - 2; ii >= 0; --ii)
-        bins[ii] = bins[ii + 1] + bin_sizes[ii + 1];
-
-      //Swap into place
-      RandomAccessIter nextbinstart = first;
-      //The last bin will always have the correct elements in it
-      for (int ii = bin_count - 1; ii > 0; --ii)
-        swap_loop<RandomAccessIter, Div_type, Right_shift>
-          (bins, nextbinstart, ii, rshift, bin_sizes, log_divisor, div_min);
-      //Update the end position of the unprocessed last bin
-      bin_cache[cache_offset] = last;
-
-      //Return if we've completed bucketsorting
-      if (!log_divisor)
-        return;
-
-      //Recursing
-      std::size_t max_count = get_min_count<float_log_mean_bin_size,
-                                            float_log_min_split_count,
-                                            float_log_finishing_count>(log_divisor);
-      RandomAccessIter lastPos = first;
-      for (int ii = cache_end - 1; ii >= static_cast<int>(cache_offset);
-          lastPos = bin_cache[ii], (void) --ii) {
-        std::size_t count = bin_cache[ii] - lastPos;
-        if (count < 2)
-          continue;
-        if (count < max_count)
-          pdqsort(lastPos, bin_cache[ii], std::less<>{}, utility::identity{});
-        else
-          negative_float_sort_rec<RandomAccessIter, Div_type, Right_shift,
-                                  Size_type>
-            (lastPos, bin_cache[ii], bin_cache, cache_end, bin_sizes, rshift);
-      }
-    }
-
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Compare, class Size_type>
-    auto negative_float_sort_rec(RandomAccessIter first, RandomAccessIter last,
-                                 std::vector<RandomAccessIter> &bin_cache, unsigned cache_offset,
-                                 std::size_t *bin_sizes, Right_shift rshift, Compare comp)
-        -> void
-    {
-      Div_type max, min;
-      if (is_sorted_or_find_extremes(first, last, max, min, rshift, comp))
-        return;
-      unsigned log_divisor = get_log_divisor<float_log_mean_bin_size>(
-          last - first, rough_log_2_size(Size_type(max - min)));
-      Div_type div_min = min >> log_divisor;
-      Div_type div_max = max >> log_divisor;
-      unsigned bin_count = unsigned(div_max - div_min) + 1;
-      unsigned cache_end;
-      RandomAccessIter * bins = size_bins(bin_sizes, bin_cache, cache_offset,
-                                          cache_end, bin_count);
-
-      //Calculating the size of each bin
-      for (RandomAccessIter current = first; current != last;)
-        bin_sizes[unsigned(rshift(*(current++), log_divisor) - div_min)]++;
-      bins[bin_count - 1] = first;
-      for (int ii = bin_count - 2; ii >= 0; --ii)
-        bins[ii] = bins[ii + 1] + bin_sizes[ii + 1];
-
-      //Swap into place
-      RandomAccessIter nextbinstart = first;
-      //The last bin will always have the correct elements in it
-      for (int ii = bin_count - 1; ii > 0; --ii)
-        swap_loop<RandomAccessIter, Div_type, Right_shift>
-          (bins, nextbinstart, ii, rshift, bin_sizes, log_divisor, div_min);
-      //Update the end position of the unprocessed last bin
-      bin_cache[cache_offset] = last;
-
-      //Return if we've completed bucketsorting
-      if (!log_divisor)
-        return;
-
-      //Recursing
-      std::size_t max_count = get_min_count<float_log_mean_bin_size,
-                                            float_log_min_split_count,
-                                            float_log_finishing_count>(log_divisor);
-      RandomAccessIter lastPos = first;
-      for (int ii = cache_end - 1; ii >= static_cast<int>(cache_offset);
-          lastPos = bin_cache[ii], --ii) {
-        std::size_t count = bin_cache[ii] - lastPos;
-        if (count < 2)
-          continue;
-        if (count < max_count)
-          pdqsort(lastPos, bin_cache[ii], comp, utility::identity{});
-        else
-          negative_float_sort_rec<RandomAccessIter, Div_type, Right_shift,
-                                  Compare, Size_type>(lastPos, bin_cache[ii],
-                                                      bin_cache, cache_end,
-                                                      bin_sizes, rshift, comp);
+            (lastPos, bin_cache[ii], bin_cache, cache_end, bin_sizes, projection);
       }
     }
 
     //Casting special-case for floating-point sorting
-    template<class RandomAccessIter, class Div_type, class Size_type>
+    template<typename RandomAccessIter, typename Div_type,
+             typename Size_type, typename Projection>
     auto float_sort_rec(RandomAccessIter first, RandomAccessIter last,
                         std::vector<RandomAccessIter> &bin_cache, unsigned cache_offset,
-                        std::size_t *bin_sizes)
+                        std::size_t *bin_sizes, Projection projection)
         -> void
     {
       Div_type max, min;
-      if (is_sorted_or_find_extremes<RandomAccessIter, Div_type>(first, last,
-                                                                max, min))
+      if (is_sorted_or_find_extremes<RandomAccessIter, Div_type>(
+        first, last, max, min, projection))
         return;
       unsigned log_divisor = get_log_divisor<float_log_mean_bin_size>(
           last - first, rough_log_2_size(Size_type(max - min)));
@@ -435,8 +283,8 @@ namespace spreadsort
 
       //Calculating the size of each bin
       for (RandomAccessIter current = first; current != last;)
-        bin_sizes[unsigned((cast_float_iter<Div_type, RandomAccessIter>(
-            current++) >> log_divisor) - div_min)]++;
+        bin_sizes[unsigned((cast_float_iter<Div_type>(
+            current++, projection) >> log_divisor) - div_min)]++;
       //The index of the first positive bin
       //Must be divided small enough to fit into an integer
       unsigned first_positive = (div_min < 0) ? unsigned(-div_min) : 0;
@@ -471,7 +319,7 @@ namespace spreadsort
       for (unsigned u = 0; u < bin_count; ++u) {
         nextbinstart = first + bin_sizes[u];
         inner_float_swap_loop<RandomAccessIter, Div_type>
-          (bins, nextbinstart, u, log_divisor, div_min);
+          (bins, nextbinstart, u, log_divisor, div_min, projection);
       }
 
       if (!log_divisor)
@@ -489,11 +337,11 @@ namespace spreadsort
         if (count < 2)
           continue;
         if (count < max_count)
-          pdqsort(lastPos, bin_cache[ii], std::less<>{}, utility::identity{});
+          pdqsort(lastPos, bin_cache[ii], std::less<>{}, projection);
         //sort negative values using reversed-bin spreadsort
         else
           negative_float_sort_rec<RandomAccessIter, Div_type, Size_type>
-            (lastPos, bin_cache[ii], bin_cache, cache_end, bin_sizes);
+            (lastPos, bin_cache[ii], bin_cache, cache_end, bin_sizes, projection);
       }
 
       for (unsigned u = cache_offset + first_positive; u < cache_end;
@@ -502,302 +350,43 @@ namespace spreadsort
         if (count < 2)
           continue;
         if (count < max_count)
-          pdqsort(lastPos, bin_cache[u], std::less<>{}, utility::identity{});
+          pdqsort(lastPos, bin_cache[u], std::less<>{}, projection);
         //sort positive values using normal spreadsort
         else
           positive_float_sort_rec<RandomAccessIter, Div_type, Size_type>
-            (lastPos, bin_cache[u], bin_cache, cache_end, bin_sizes);
-      }
-    }
-
-    //Functor implementation for recursive sorting
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Size_type>
-    auto float_sort_rec(RandomAccessIter first, RandomAccessIter last,
-                        std::vector<RandomAccessIter> &bin_cache, unsigned cache_offset,
-                        std::size_t *bin_sizes, Right_shift rshift)
-        -> void
-    {
-      Div_type max, min;
-      if (is_sorted_or_find_extremes(first, last, max, min, rshift))
-        return;
-      unsigned log_divisor = get_log_divisor<float_log_mean_bin_size>(
-          last - first, rough_log_2_size(Size_type(max - min)));
-      Div_type div_min = min >> log_divisor;
-      Div_type div_max = max >> log_divisor;
-      unsigned bin_count = unsigned(div_max - div_min) + 1;
-      unsigned cache_end;
-      RandomAccessIter * bins = size_bins(bin_sizes, bin_cache, cache_offset,
-                                          cache_end, bin_count);
-
-      //Calculating the size of each bin
-      for (RandomAccessIter current = first; current != last;)
-        bin_sizes[unsigned(rshift(*(current++), log_divisor) - div_min)]++;
-      //The index of the first positive bin
-      unsigned first_positive = (div_min < 0) ? unsigned(-div_min) : 0;
-      //Resetting if all bins are negative
-      if (cache_offset + first_positive > cache_end)
-        first_positive = cache_end - cache_offset;
-      //Reversing the order of the negative bins
-      //Note that because of the negative/positive ordering direction flip
-      //We can not depend upon bin order and positions matching up
-      //so bin_sizes must be reused to contain the end of the bin
-      if (first_positive > 0) {
-        bins[first_positive - 1] = first;
-        for (int ii = first_positive - 2; ii >= 0; --ii) {
-          bins[ii] = first + bin_sizes[ii + 1];
-          bin_sizes[ii] += bin_sizes[ii + 1];
-        }
-        //Handling positives following negatives
-        if (static_cast<unsigned>(first_positive) < bin_count) {
-          bins[first_positive] = first + bin_sizes[0];
-          bin_sizes[first_positive] += bin_sizes[0];
-        }
-      }
-      else
-        bins[0] = first;
-      for (unsigned u = first_positive; u < bin_count - 1; u++) {
-        bins[u + 1] = first + bin_sizes[u];
-        bin_sizes[u + 1] += bin_sizes[u];
-      }
-
-      //Swap into place
-      RandomAccessIter next_bin_start = first;
-      for (unsigned u = 0; u < bin_count; ++u) {
-        next_bin_start = first + bin_sizes[u];
-        inner_swap_loop<RandomAccessIter, Div_type, Right_shift>
-          (bins, next_bin_start, u, rshift, log_divisor, div_min);
-      }
-
-      //Return if we've completed bucketsorting
-      if (!log_divisor)
-        return;
-
-      //Handling negative values first
-      std::size_t max_count = get_min_count<float_log_mean_bin_size,
-                                            float_log_min_split_count,
-                                            float_log_finishing_count>(log_divisor);
-      RandomAccessIter lastPos = first;
-      for (int ii = cache_offset + first_positive - 1;
-           ii >= static_cast<int>(cache_offset);
-           lastPos = bin_cache[ii--]) {
-        std::size_t count = bin_cache[ii] - lastPos;
-        if (count < 2)
-          continue;
-        if (count < max_count)
-          pdqsort(lastPos, bin_cache[ii], std::less<>{}, utility::identity{});
-        //sort negative values using reversed-bin spreadsort
-        else
-          negative_float_sort_rec<RandomAccessIter, Div_type,
-            Right_shift, Size_type>(lastPos, bin_cache[ii], bin_cache,
-                                    cache_end, bin_sizes, rshift);
-      }
-
-      for (unsigned u = cache_offset + first_positive; u < cache_end;
-          lastPos = bin_cache[u], (void) ++u) {
-        std::size_t count = bin_cache[u] - lastPos;
-        if (count < 2)
-          continue;
-        if (count < max_count)
-          pdqsort(lastPos, bin_cache[u], std::less<>{}, utility::identity{});
-        //sort positive values using normal spreadsort
-        else
-          spreadsort_rec<RandomAccessIter, Div_type, Right_shift, Size_type,
-                          float_log_mean_bin_size, float_log_min_split_count,
-                          float_log_finishing_count>
-            (lastPos, bin_cache[u], bin_cache, cache_end, bin_sizes, rshift);
-      }
-    }
-
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Compare, class Size_type>
-    auto float_sort_rec(RandomAccessIter first, RandomAccessIter last,
-                        std::vector<RandomAccessIter> &bin_cache, unsigned cache_offset,
-                        std::size_t *bin_sizes, Right_shift rshift, Compare comp)
-        -> void
-    {
-      Div_type max, min;
-      if (is_sorted_or_find_extremes(first, last, max, min, rshift, comp))
-        return;
-      unsigned log_divisor = get_log_divisor<float_log_mean_bin_size>(
-          last - first, rough_log_2_size(Size_type(max - min)));
-      Div_type div_min = min >> log_divisor;
-      Div_type div_max = max >> log_divisor;
-      unsigned bin_count = unsigned(div_max - div_min) + 1;
-      unsigned cache_end;
-      RandomAccessIter * bins = size_bins(bin_sizes, bin_cache, cache_offset,
-                                          cache_end, bin_count);
-
-      //Calculating the size of each bin
-      for (RandomAccessIter current = first; current != last;)
-        bin_sizes[unsigned(rshift(*(current++), log_divisor) - div_min)]++;
-      //The index of the first positive bin
-      unsigned first_positive =
-        (div_min < 0) ? static_cast<unsigned>(-div_min) : 0;
-      //Resetting if all bins are negative
-      if (cache_offset + first_positive > cache_end)
-        first_positive = cache_end - cache_offset;
-      //Reversing the order of the negative bins
-      //Note that because of the negative/positive ordering direction flip
-      //We can not depend upon bin order and positions matching up
-      //so bin_sizes must be reused to contain the end of the bin
-      if (first_positive > 0) {
-        bins[first_positive - 1] = first;
-        for (int ii = first_positive - 2; ii >= 0; --ii) {
-          bins[ii] = first + bin_sizes[ii + 1];
-          bin_sizes[ii] += bin_sizes[ii + 1];
-        }
-        //Handling positives following negatives
-        if (static_cast<unsigned>(first_positive) < bin_count) {
-          bins[first_positive] = first + bin_sizes[0];
-          bin_sizes[first_positive] += bin_sizes[0];
-        }
-      }
-      else
-        bins[0] = first;
-      for (unsigned u = first_positive; u < bin_count - 1; u++) {
-        bins[u + 1] = first + bin_sizes[u];
-        bin_sizes[u + 1] += bin_sizes[u];
-      }
-
-      //Swap into place
-      RandomAccessIter next_bin_start = first;
-      for (unsigned u = 0; u < bin_count; ++u) {
-        next_bin_start = first + bin_sizes[u];
-        inner_swap_loop<RandomAccessIter, Div_type, Right_shift>
-          (bins, next_bin_start, u, rshift, log_divisor, div_min);
-      }
-
-      //Return if we've completed bucketsorting
-      if (!log_divisor)
-        return;
-
-      //Handling negative values first
-      std::size_t max_count = get_min_count<float_log_mean_bin_size,
-                                            float_log_min_split_count,
-                                            float_log_finishing_count>(log_divisor);
-      RandomAccessIter lastPos = first;
-      for (int ii = cache_offset + first_positive - 1;
-           ii >= static_cast<int>(cache_offset);
-           lastPos = bin_cache[ii--]) {
-        std::size_t count = bin_cache[ii] - lastPos;
-        if (count < 2)
-          continue;
-        if (count < max_count)
-          pdqsort(lastPos, bin_cache[ii], comp, utility::identity{});
-        //sort negative values using reversed-bin spreadsort
-        else
-          negative_float_sort_rec<RandomAccessIter, Div_type, Right_shift,
-                                  Compare, Size_type>(lastPos, bin_cache[ii],
-                                                      bin_cache, cache_end,
-                                                      bin_sizes, rshift, comp);
-      }
-
-      for (unsigned u = cache_offset + first_positive; u < cache_end;
-          lastPos = bin_cache[u], (void) ++u) {
-        std::size_t count = bin_cache[u] - lastPos;
-        if (count < 2)
-          continue;
-        if (count < max_count)
-          pdqsort(lastPos, bin_cache[u], comp, utility::identity{});
-        //sort positive values using normal spreadsort
-        else
-          spreadsort_rec<RandomAccessIter, Div_type, Right_shift, Compare,
-                          Size_type, float_log_mean_bin_size,
-                          float_log_min_split_count, float_log_finishing_count>
-      (lastPos, bin_cache[u], bin_cache, cache_end, bin_sizes, rshift, comp);
+            (lastPos, bin_cache[u], bin_cache, cache_end, bin_sizes, projection);
       }
     }
 
     //Checking whether the value type is a float, and trying a 32-bit integer
-    template<class RandomAccessIter>
-    auto float_sort(RandomAccessIter first, RandomAccessIter last)
-        -> std::enable_if_t< sizeof(std::uint32_t) ==
-            sizeof(value_type_t<RandomAccessIter>)
-            && std::numeric_limits<
-            value_type_t<RandomAccessIter>>::is_iec559,
+    template<typename RandomAccessIter, typename Projection>
+    auto float_sort(RandomAccessIter first, RandomAccessIter last, Projection projection)
+        -> std::enable_if_t<
+            sizeof(std::uint32_t) == sizeof(projected_t<RandomAccessIter, Projection>) &&
+            std::numeric_limits<projected_t<RandomAccessIter, Projection>>::is_iec559,
             void
         >
     {
       std::size_t bin_sizes[1 << max_finishing_splits];
       std::vector<RandomAccessIter> bin_cache;
       float_sort_rec<RandomAccessIter, std::int32_t, std::uint32_t>
-        (first, last, bin_cache, 0, bin_sizes);
+        (first, last, bin_cache, 0, bin_sizes, projection);
     }
 
     //Checking whether the value type is a double, and using a 64-bit integer
-    template<class RandomAccessIter>
-    auto float_sort(RandomAccessIter first, RandomAccessIter last)
-        -> std::enable_if_t< sizeof(std::uint64_t) ==
-            sizeof(value_type_t<RandomAccessIter>)
-            && std::numeric_limits<
-            value_type_t<RandomAccessIter>>::is_iec559,
+    template<typename RandomAccessIter, typename Projection>
+    auto float_sort(RandomAccessIter first, RandomAccessIter last, Projection projection)
+        -> std::enable_if_t<
+            sizeof(std::uint64_t) == sizeof(projected_t<RandomAccessIter, Projection>) &&
+            std::numeric_limits<projected_t<RandomAccessIter, Projection>>::is_iec559,
             void
         >
     {
       std::size_t bin_sizes[1 << max_finishing_splits];
       std::vector<RandomAccessIter> bin_cache;
       float_sort_rec<RandomAccessIter, std::int64_t, std::uint64_t>
-        (first, last, bin_cache, 0, bin_sizes);
+        (first, last, bin_cache, 0, bin_sizes, projection);
     }
-
-    //These approaches require the user to do the typecast
-    //with rshift but default comparision
-    template<class RandomAccessIter, class Div_type, class Right_shift>
-    auto float_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
-                    Right_shift rshift)
-        -> std::enable_if_t< sizeof(std::size_t) >= sizeof(Div_type), void >
-    {
-      std::size_t bin_sizes[1 << max_finishing_splits];
-      std::vector<RandomAccessIter> bin_cache;
-      float_sort_rec<RandomAccessIter, Div_type, Right_shift, std::size_t>
-        (first, last, bin_cache, 0, bin_sizes, rshift);
-    }
-
-    //maximum integer size with rshift but default comparision
-    template<class RandomAccessIter, class Div_type, class Right_shift>
-    auto float_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
-               Right_shift rshift)
-        -> std::enable_if_t< sizeof(std::size_t) < sizeof(Div_type)
-            && sizeof(std::uintmax_t) >= sizeof(Div_type), void
-        >
-    {
-      std::size_t bin_sizes[1 << max_finishing_splits];
-      std::vector<RandomAccessIter> bin_cache;
-      float_sort_rec<RandomAccessIter, Div_type, Right_shift, std::uintmax_t>
-        (first, last, bin_cache, 0, bin_sizes, rshift);
-    }
-
-    //specialized comparison
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Compare>
-    auto float_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
-                    Right_shift rshift, Compare comp)
-        -> std::enable_if_t< sizeof(std::size_t) >= sizeof(Div_type), void >
-    {
-      std::size_t bin_sizes[1 << max_finishing_splits];
-      std::vector<RandomAccessIter> bin_cache;
-      float_sort_rec<RandomAccessIter, Div_type, Right_shift, Compare,
-        std::size_t>
-        (first, last, bin_cache, 0, bin_sizes, rshift, comp);
-    }
-
-    //max-sized integer with specialized comparison
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Compare>
-    auto float_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
-                    Right_shift rshift, Compare comp)
-        -> std::enable_if_t< sizeof(std::size_t) < sizeof(Div_type)
-            && sizeof(std::uintmax_t) >= sizeof(Div_type), void
-        >
-    {
-      std::size_t bin_sizes[1 << max_finishing_splits];
-      std::vector<RandomAccessIter> bin_cache;
-      float_sort_rec<RandomAccessIter, Div_type, Right_shift, Compare,
-        std::uintmax_t>
-        (first, last, bin_cache, 0, bin_sizes, rshift, comp);
-    }
-  }
-}}}
+}}}}
 
 #endif // CPPSORT_DETAIL_SPREADSORT_DETAIL_FLOAT_SORT_H_

--- a/include/cpp-sort/detail/spreadsort/detail/integer_sort.h
+++ b/include/cpp-sort/detail/spreadsort/detail/integer_sort.h
@@ -26,7 +26,7 @@ Phil Endecott and Frank Gennari
 #include <iterator>
 #include <type_traits>
 #include <vector>
-#include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/as_function.h>
 #include "common.h"
 #include "constants.h"
 #include "../../iterator_traits.h"
@@ -41,14 +41,17 @@ namespace spreadsort
   namespace detail {
     // Return true if the list is sorted.  Otherwise, find the minimum and
     // maximum using <.
-    template<class RandomAccessIter>
+    template<typename RandomAccessIter, typename Projection>
     auto is_sorted_or_find_extremes(RandomAccessIter current, RandomAccessIter last,
-                                    RandomAccessIter & max, RandomAccessIter & min)
+                                    RandomAccessIter & max, RandomAccessIter & min,
+                                    Projection projection)
         -> bool
     {
+      auto&& proj = utility::as_function(projection);
+
       min = max = current;
       //This assumes we have more than 1 element based on prior checks.
-      while (!(*(current + 1) < *current)) {
+      while (!(proj(*(current + 1)) < proj(*current))) {
         //If everything is in sorted order, return
         if (++current == last - 1)
           return true;
@@ -58,36 +61,9 @@ namespace spreadsort
       max = current;
       //Start from the first unsorted element
       while (++current < last) {
-        if (*max < *current)
+        if (proj(*max) < proj(*current))
           max = current;
-        else if (*current < *min)
-          min = current;
-      }
-      return false;
-    }
-
-    // Return true if the list is sorted.  Otherwise, find the minimum and
-    // maximum.
-    // Use a user-defined comparison operator
-    template<class RandomAccessIter, class Compare>
-    auto is_sorted_or_find_extremes(RandomAccessIter current, RandomAccessIter last,
-                                    RandomAccessIter & max, RandomAccessIter & min,
-                                    Compare comp)
-        -> bool
-    {
-      min = max = current;
-      while (!comp(*(current + 1), *current)) {
-        //If everything is in sorted order, return
-        if (++current == last - 1)
-          return true;
-      }
-
-      //The maximum is the last sorted element
-      max = current;
-      while (++current < last) {
-        if (comp(*max, *current))
-          max = current;
-        else if (comp(*current, *min))
+        else if (proj(*current) < proj(*min))
           min = current;
       }
       return false;
@@ -115,24 +91,27 @@ namespace spreadsort
     }
 
     //Implementation for recursive integer sorting
-    template<class RandomAccessIter, class Div_type, class Size_type>
+    template<typename RandomAccessIter, typename Div_type,
+             typename Size_type, typename Projection>
     auto spreadsort_rec(RandomAccessIter first, RandomAccessIter last,
                         std::vector<RandomAccessIter> &bin_cache, unsigned cache_offset,
-                        std::size_t *bin_sizes)
+                        std::size_t *bin_sizes, Projection projection)
         -> void
     {
+      auto&& proj = utility::as_function(projection);
+
       //This step is roughly 10% of runtime, but it helps avoid worst-case
       //behavior and improve behavior with real data
       //If you know the maximum and minimum ahead of time, you can pass those
       //values in and skip this step for the first iteration
       RandomAccessIter max, min;
-      if (is_sorted_or_find_extremes(first, last, max, min))
+      if (is_sorted_or_find_extremes(first, last, max, min, projection))
         return;
       RandomAccessIter * target_bin;
       unsigned log_divisor = get_log_divisor<int_log_mean_bin_size>(
-          last - first, rough_log_2_size(Size_type((*max >> 0) - (*min >> 0))));
-      Div_type div_min = *min >> log_divisor;
-      Div_type div_max = *max >> log_divisor;
+          last - first, rough_log_2_size(Size_type((proj(*max) >> 0) - (proj(*min) >> 0))));
+      Div_type div_min = proj(*min) >> log_divisor;
+      Div_type div_max = proj(*max) >> log_divisor;
       unsigned bin_count = unsigned(div_max - div_min) + 1;
       unsigned cache_end;
       RandomAccessIter * bins =
@@ -140,7 +119,7 @@ namespace spreadsort
 
       //Calculating the size of each bin; this takes roughly 10% of runtime
       for (RandomAccessIter current = first; current != last;)
-        bin_sizes[std::size_t((*(current++) >> log_divisor) - div_min)]++;
+        bin_sizes[std::size_t((proj(*(current++)) >> log_divisor) - div_min)]++;
       //Assign the bin positions
       bins[0] = first;
       for (unsigned u = 0; u < bin_count - 1; u++)
@@ -157,15 +136,15 @@ namespace spreadsort
             ++current) {
           //Swapping elements in current into place until the correct
           //element has been swapped in
-          for (target_bin = (bins + ((*current >> log_divisor) - div_min));
+          for (target_bin = (bins + ((proj(*current) >> log_divisor) - div_min));
               target_bin != local_bin;
-            target_bin = bins + ((*current >> log_divisor) - div_min)) {
+            target_bin = bins + ((proj(*current) >> log_divisor) - div_min)) {
             //3-way swap; this is about 1% faster than a 2-way swap
             //The main advantage is less copies are involved per item
             //put in the correct place
             value_type_t<RandomAccessIter> tmp;
             RandomAccessIter b = (*target_bin)++;
-            RandomAccessIter * b_bin = bins + ((*b >> log_divisor) - div_min);
+            RandomAccessIter * b_bin = bins + ((proj(*b) >> log_divisor) - div_min);
             if (b_bin != local_bin) {
               RandomAccessIter c = (*b_bin)++;
               tmp = *c;
@@ -199,13 +178,14 @@ namespace spreadsort
           continue;
         //using pdqsort if its worst-case is better
         if (count < max_count)
-          pdqsort(lastPos, bin_cache[u], std::less<>{}, utility::identity{});
+          pdqsort(lastPos, bin_cache[u], std::less<>{}, projection);
         else
           spreadsort_rec<RandomAccessIter, Div_type, Size_type>(lastPos,
-                                                                 bin_cache[u],
-                                                                 bin_cache,
-                                                                 cache_end,
-                                                                 bin_sizes);
+                                                                bin_cache[u],
+                                                                bin_cache,
+                                                                cache_end,
+                                                                bin_sizes,
+                                                                projection);
       }
     }
 
@@ -258,208 +238,37 @@ namespace spreadsort
                               next_bin_start, ii, rshift, log_divisor, div_min);
     }
 
-    //Functor implementation for recursive sorting
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Compare, class Size_type, unsigned log_mean_bin_size,
-             unsigned log_min_split_count, unsigned log_finishing_count>
-    auto spreadsort_rec(RandomAccessIter first, RandomAccessIter last,
-                        std::vector<RandomAccessIter> &bin_cache, unsigned cache_offset,
-                        std::size_t *bin_sizes, Right_shift rshift, Compare comp)
-        -> void
-    {
-      RandomAccessIter max, min;
-      if (is_sorted_or_find_extremes(first, last, max, min, comp))
-        return;
-      unsigned log_divisor = get_log_divisor<log_mean_bin_size>(last - first,
-            rough_log_2_size(Size_type(rshift(*max, 0) - rshift(*min, 0))));
-      Div_type div_min = rshift(*min, log_divisor);
-      Div_type div_max = rshift(*max, log_divisor);
-      unsigned bin_count = unsigned(div_max - div_min) + 1;
-      unsigned cache_end;
-      RandomAccessIter * bins = size_bins(bin_sizes, bin_cache, cache_offset,
-                                          cache_end, bin_count);
-
-      //Calculating the size of each bin
-      for (RandomAccessIter current = first; current != last;)
-        bin_sizes[unsigned(rshift(*(current++), log_divisor) - div_min)]++;
-      bins[0] = first;
-      for (unsigned u = 0; u < bin_count - 1; u++)
-        bins[u + 1] = bins[u] + bin_sizes[u];
-
-      //Swap into place
-      RandomAccessIter next_bin_start = first;
-      for (unsigned u = 0; u < bin_count - 1; ++u)
-        swap_loop<RandomAccessIter, Div_type, Right_shift>(bins, next_bin_start,
-                                  u, rshift, bin_sizes, log_divisor, div_min);
-      bins[bin_count - 1] = last;
-
-      //If we've bucketsorted, the array is sorted
-      if (!log_divisor)
-        return;
-
-      //Recursing
-      std::size_t max_count = get_min_count<log_mean_bin_size, log_min_split_count,
-                          log_finishing_count>(log_divisor);
-      RandomAccessIter lastPos = first;
-      for (unsigned u = cache_offset; u < cache_end; lastPos = bin_cache[u],
-          (void) ++u) {
-        std::size_t count = bin_cache[u] - lastPos;
-        if (count < 2)
-          continue;
-        if (count < max_count)
-          pdqsort(lastPos, bin_cache[u], comp, utility::identity{});
-        else
-          spreadsort_rec<RandomAccessIter, Div_type, Right_shift, Compare,
-        Size_type, log_mean_bin_size, log_min_split_count, log_finishing_count>
-      (lastPos, bin_cache[u], bin_cache, cache_end, bin_sizes, rshift, comp);
-      }
-    }
-
-    //Functor implementation for recursive sorting with only Shift overridden
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Size_type, unsigned log_mean_bin_size,
-             unsigned log_min_split_count, unsigned log_finishing_count>
-    auto spreadsort_rec(RandomAccessIter first, RandomAccessIter last,
-                        std::vector<RandomAccessIter> &bin_cache, unsigned cache_offset,
-                        std::size_t *bin_sizes, Right_shift rshift)
-        -> void
-    {
-      RandomAccessIter max, min;
-      if (is_sorted_or_find_extremes(first, last, max, min))
-        return;
-      unsigned log_divisor = get_log_divisor<log_mean_bin_size>(last - first,
-            rough_log_2_size(Size_type(rshift(*max, 0) - rshift(*min, 0))));
-      Div_type div_min = rshift(*min, log_divisor);
-      Div_type div_max = rshift(*max, log_divisor);
-      unsigned bin_count = unsigned(div_max - div_min) + 1;
-      unsigned cache_end;
-      RandomAccessIter * bins = size_bins(bin_sizes, bin_cache, cache_offset,
-                                          cache_end, bin_count);
-
-      //Calculating the size of each bin
-      for (RandomAccessIter current = first; current != last;)
-        bin_sizes[unsigned(rshift(*(current++), log_divisor) - div_min)]++;
-      bins[0] = first;
-      for (unsigned u = 0; u < bin_count - 1; u++)
-        bins[u + 1] = bins[u] + bin_sizes[u];
-
-      //Swap into place
-      RandomAccessIter nextbinstart = first;
-      for (unsigned ii = 0; ii < bin_count - 1; ++ii)
-        swap_loop<RandomAccessIter, Div_type, Right_shift>(bins, nextbinstart,
-                                ii, rshift, bin_sizes, log_divisor, div_min);
-      bins[bin_count - 1] = last;
-
-      //If we've bucketsorted, the array is sorted
-      if (!log_divisor)
-        return;
-
-      //Recursing
-      std::size_t max_count = get_min_count<log_mean_bin_size, log_min_split_count,
-                          log_finishing_count>(log_divisor);
-      RandomAccessIter lastPos = first;
-      for (unsigned u = cache_offset; u < cache_end; lastPos = bin_cache[u],
-          (void) ++u) {
-        std::size_t count = bin_cache[u] - lastPos;
-        if (count < 2)
-          continue;
-        if (count < max_count)
-          pdqsort(lastPos, bin_cache[u], utility::identity{});
-        else
-          spreadsort_rec<RandomAccessIter, Div_type, Right_shift, Size_type,
-          log_mean_bin_size, log_min_split_count, log_finishing_count>(lastPos,
-                      bin_cache[u], bin_cache, cache_end, bin_sizes, rshift);
-      }
-    }
-
     //Holds the bin vector and makes the initial recursive call
     //Only use spreadsort if the integer can fit in a std::size_t
-    template<class RandomAccessIter, class Div_type>
-    auto integer_sort(RandomAccessIter first, RandomAccessIter last, Div_type)
-        -> std::enable_if_t< sizeof(Div_type) <= sizeof(std::size_t), void >
+    template<typename RandomAccessIter, typename Div_type, typename Projection>
+    auto integer_sort(RandomAccessIter first, RandomAccessIter last,
+                      Div_type, Projection projection)
+        -> std::enable_if_t<
+            sizeof(Div_type) <= sizeof(std::size_t),
+            void
+        >
     {
       std::size_t bin_sizes[1 << max_finishing_splits];
       std::vector<RandomAccessIter> bin_cache;
-      spreadsort_rec<RandomAccessIter, Div_type, std::size_t>(first, last,
-          bin_cache, 0, bin_sizes);
+      spreadsort_rec<RandomAccessIter, Div_type, std::size_t, Projection>(
+          first, last, bin_cache, 0, bin_sizes, projection);
     }
 
     //Holds the bin vector and makes the initial recursive call
     //Only use spreadsort if the integer can fit in a std::uintmax_t
-    template<class RandomAccessIter, class Div_type>
-    auto integer_sort(RandomAccessIter first, RandomAccessIter last, Div_type)
-        -> std::enable_if_t< (sizeof(Div_type) > sizeof(std::size_t))
-            && sizeof(Div_type) <= sizeof(std::uintmax_t), void
+    template<typename RandomAccessIter, typename Div_type, typename Projection>
+    auto integer_sort(RandomAccessIter first, RandomAccessIter last,
+                      Div_type, Projection projection)
+        -> std::enable_if_t<
+            (sizeof(Div_type) > sizeof(std::size_t)) &&
+            sizeof(Div_type) <= sizeof(std::uintmax_t),
+            void
         >
     {
       std::size_t bin_sizes[1 << max_finishing_splits];
       std::vector<RandomAccessIter> bin_cache;
-      spreadsort_rec<RandomAccessIter, Div_type, std::uintmax_t>(first,
-          last, bin_cache, 0, bin_sizes);
-    }
-
-    //Same for the full functor version
-    //Only use spreadsort if the integer can fit in a std::size_t
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Compare>
-    auto integer_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
-                      Right_shift shift, Compare comp)
-        -> std::enable_if_t< sizeof(Div_type) <= sizeof(std::size_t), void >
-    {
-      std::size_t bin_sizes[1 << max_finishing_splits];
-      std::vector<RandomAccessIter> bin_cache;
-      spreadsort_rec<RandomAccessIter, Div_type, Right_shift, Compare,
-          std::size_t, int_log_mean_bin_size, int_log_min_split_count,
-                        int_log_finishing_count>
-          (first, last, bin_cache, 0, bin_sizes, shift, comp);
-    }
-
-    //Only use spreadsort if the integer can fit in a std::uintmax_t
-    template<class RandomAccessIter, class Div_type, class Right_shift,
-             class Compare>
-    auto integer_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
-                      Right_shift shift, Compare comp)
-        -> std::enable_if_t< (sizeof(Div_type) > sizeof(std::size_t))
-            && sizeof(Div_type) <= sizeof(std::uintmax_t), void
-        >
-    {
-      std::size_t bin_sizes[1 << max_finishing_splits];
-      std::vector<RandomAccessIter> bin_cache;
-      spreadsort_rec<RandomAccessIter, Div_type, Right_shift, Compare,
-                        std::uintmax_t, int_log_mean_bin_size,
-                        int_log_min_split_count, int_log_finishing_count>
-          (first, last, bin_cache, 0, bin_sizes, shift, comp);
-    }
-
-    //Same for the right shift version
-    //Only use spreadsort if the integer can fit in a std::size_t
-    template<class RandomAccessIter, class Div_type, class Right_shift>
-    auto integer_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
-                      Right_shift shift)
-        -> std::enable_if_t< sizeof(Div_type) <= sizeof(std::size_t), void >
-    {
-      std::size_t bin_sizes[1 << max_finishing_splits];
-      std::vector<RandomAccessIter> bin_cache;
-      spreadsort_rec<RandomAccessIter, Div_type, Right_shift, std::size_t,
-          int_log_mean_bin_size, int_log_min_split_count,
-                        int_log_finishing_count>
-          (first, last, bin_cache, 0, bin_sizes, shift);
-    }
-
-    //Only use spreadsort if the integer can fit in a std::uintmax_t
-    template<class RandomAccessIter, class Div_type, class Right_shift>
-    auto integer_sort(RandomAccessIter first, RandomAccessIter last, Div_type,
-                      Right_shift shift)
-        -> std::enable_if_t< (sizeof(Div_type) > sizeof(std::size_t))
-            && sizeof(Div_type) <= sizeof(std::uintmax_t), void
-        >
-    {
-      std::size_t bin_sizes[1 << max_finishing_splits];
-      std::vector<RandomAccessIter> bin_cache;
-      spreadsort_rec<RandomAccessIter, Div_type, Right_shift,
-                        std::uintmax_t, int_log_mean_bin_size,
-                        int_log_min_split_count, int_log_finishing_count>
-          (first, last, bin_cache, 0, bin_sizes, shift);
+      spreadsort_rec<RandomAccessIter, Div_type, std::uintmax_t, Projection>(
+          first, last, bin_cache, 0, bin_sizes, projection);
     }
   }
 }}}

--- a/include/cpp-sort/detail/spreadsort/detail/string_sort.h
+++ b/include/cpp-sort/detail/spreadsort/detail/string_sort.h
@@ -30,7 +30,6 @@ Phil Endecott and Frank Gennari
 #include <cpp-sort/utility/functional.h>
 #include "common.h"
 #include "constants.h"
-#include "../../iterator_traits.h"
 
 namespace cppsort
 {
@@ -86,14 +85,15 @@ namespace spreadsort
     }
 
     //This comparison functor assumes strings are identical up to char_offset
-    template<typename Data_type, typename Projection, typename Unsigned_char_type>
+    template<typename Projection, typename Unsigned_char_type>
     struct offset_less_than
     {
         offset_less_than(std::size_t char_offset, Projection projection):
             data(char_offset, projection)
         {}
 
-        auto operator()(const Data_type& x, const Data_type& y) const
+        template<typename T, typename U>
+        auto operator()(const T& x, const U& y) const
             -> bool
         {
             auto&& proj = utility::as_function(std::get<1>(data));
@@ -117,14 +117,15 @@ namespace spreadsort
     };
 
     //Compares strings assuming they are identical up to char_offset
-    template<typename Data_type, typename Projection, typename Unsigned_char_type>
+    template<typename Projection, typename Unsigned_char_type>
     struct offset_greater_than
     {
         offset_greater_than(std::size_t char_offset, Projection projection):
             data(char_offset, projection)
         {}
 
-        auto operator()(const Data_type& x, const Data_type& y) const
+        template<typename T, typename U>
+        auto operator()(const T& x, const U& y) const
             -> bool
         {
             auto&& proj = utility::as_function(std::get<1>(data));
@@ -156,7 +157,6 @@ namespace spreadsort
                          Projection projection)
         -> void
     {
-      using Data_type = value_type_t<RandomAccessIter>;
       auto&& proj = utility::as_function(projection);
 
       //This section makes handling of long identical substrings much faster
@@ -246,7 +246,7 @@ namespace spreadsort
         //using pdqsort if its worst-case is better
         if (count < max_size)
           pdqsort(lastPos, bin_cache[u],
-                  offset_less_than<Data_type, Projection, Unsigned_char_type>(
+                  offset_less_than<Projection, Unsigned_char_type>(
                     char_offset + 1, projection),
                   utility::identity{});
         else
@@ -264,7 +264,6 @@ namespace spreadsort
                                  Projection projection)
         -> void
     {
-      using Data_type = value_type_t<RandomAccessIter>;
       auto&& proj = utility::as_function(projection);
 
       //This section makes handling of long identical substrings much faster
@@ -359,7 +358,7 @@ namespace spreadsort
         //using pdqsort if its worst-case is better
         if (count < max_size)
           pdqsort(lastPos, bin_cache[u],
-                  offset_greater_than<Data_type, Projection, Unsigned_char_type>(
+                  offset_greater_than<Projection, Unsigned_char_type>(
                     char_offset + 1, projection),
                   utility::identity{});
         else

--- a/include/cpp-sort/detail/spreadsort/float_sort.h
+++ b/include/cpp-sort/detail/spreadsort/float_sort.h
@@ -10,8 +10,6 @@
 /*
 Some improvements suggested by:
 Phil Endecott and Frank Gennari
-float_mem_cast fix provided by:
-Scott McMurray
 */
 
 // Modified in 2015-2016 by Morwenn for inclusion into cpp-sort
@@ -25,7 +23,6 @@ Scott McMurray
 #include <cstring>
 #include <functional>
 #include <limits>
-#include <cpp-sort/utility/functional.h>
 #include "detail/constants.h"
 #include "detail/float_sort.h"
 #include "../pdqsort.h"
@@ -36,35 +33,6 @@ namespace detail
 {
 namespace spreadsort
 {
-  /*!
-  \brief Casts a float to the specified integer type.
-
-  \tparam Data_type Floating-point IEEE 754/IEC559 type.
-  \tparam Cast_type Integer type (same size) to which to cast.
-
-  \par Example:
-  \code
-  struct rightshift {
-    int operator()(const DATA_TYPE &x, const unsigned offset) const {
-      return float_mem_cast<KEY_TYPE, CAST_TYPE>(x.key) >> offset;
-    }
-  };
-  \endcode
-  */
-  template<class Data_type, class Cast_type>
-  auto float_mem_cast(const Data_type & data)
-      -> Cast_type
-  {
-    // Only cast IEEE floating-point numbers, and only to a same-sized integer.
-    static_assert(sizeof(Cast_type) == sizeof(Data_type), "");
-    static_assert(std::numeric_limits<Data_type>::is_iec559, "");
-    static_assert(std::numeric_limits<Cast_type>::is_integer, "");
-    Cast_type result;
-    std::memcpy(&result, &data, sizeof(Cast_type));
-    return result;
-  }
-
-
   /*!
     \brief @c float_sort with casting to the appropriate size.
 
@@ -89,54 +57,14 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
    \par The sorted vector contains ascending values "1.0 1.3 2.3".
 
   */
-  template<class RandomAccessIter>
-  auto float_sort(RandomAccessIter first, RandomAccessIter last)
+  template<typename RandomAccessIter, typename Projection>
+  auto float_sort(RandomAccessIter first, RandomAccessIter last, Projection projection)
       -> void
   {
     if (last - first < detail::min_sort_size)
-      pdqsort(first, last, std::less<>{}, utility::identity{});
+      pdqsort(first, last, std::less<>{}, projection);
     else
-      detail::float_sort(first, last);
-  }
-
-  /*!
-    \brief Floating-point sort algorithm using random access iterators with just right-shift functor.
-
-    \param[in] first Iterator pointer to first element.
-    \param[in] last Iterator pointing to one beyond the end of data.
-    \param[in] rshift Functor that returns the result of shifting the value_type right a specified number of bits.
-
-  */
-  template<class RandomAccessIter, class Right_shift>
-  auto float_sort(RandomAccessIter first, RandomAccessIter last,
-                  Right_shift rshift)
-      -> void
-  {
-    if (last - first < detail::min_sort_size)
-      pdqsort(first, last, std::less<>{}, utility::identity{});
-    else
-      detail::float_sort(first, last, rshift(*first, 0), rshift);
-  }
-
-
-  /*!
-   \brief Float sort algorithm using random access iterators with both right-shift and user-defined comparison operator.
-
-   \param[in] first Iterator pointer to first element.
-   \param[in] last Iterator pointing to one beyond the end of data.
-   \param[in] rshift Functor that returns the result of shifting the value_type right a specified number of bits.
-   \param[in] comp A binary functor that returns whether the first element passed to it should go before the second in order.
-  */
-
-  template<class RandomAccessIter, class Right_shift, class Compare>
-  auto float_sort(RandomAccessIter first, RandomAccessIter last,
-                  Right_shift rshift, Compare comp)
-      -> void
-  {
-    if (last - first < detail::min_sort_size)
-      pdqsort(first, last, comp, utility::identity{});
-    else
-      detail::float_sort(first, last, rshift(*first, 0), rshift, comp);
+      detail::float_sort(first, last, projection);
   }
 }}}
 

--- a/include/cpp-sort/detail/spreadsort/string_sort.h
+++ b/include/cpp-sort/detail/spreadsort/string_sort.h
@@ -21,7 +21,6 @@ Phil Endecott and Frank Gennari
 // Headers
 ////////////////////////////////////////////////////////////
 #include <functional>
-#include <cpp-sort/utility/functional.h>
 #include "detail/constants.h"
 #include "detail/string_sort.h"
 #include "../pdqsort.h"
@@ -77,67 +76,17 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
 
 */
 
-  template<class RandomAccessIter, class Unsigned_char_type>
+  template<typename RandomAccessIter, typename Projection, typename Unsigned_char_type>
   auto string_sort(RandomAccessIter first, RandomAccessIter last,
-                   Unsigned_char_type unused)
+                   Projection projection, Unsigned_char_type unused)
       -> void
   {
     //Don't sort if it's too small to optimize
     if (last - first < detail::min_sort_size)
-      pdqsort(first, last, std::less<>{}, utility::identity{});
+      pdqsort(first, last, std::less<>{}, projection);
     else
-      detail::string_sort(first, last, unused);
+      detail::string_sort(first, last, projection, unused);
   }
-
-
-/*! \brief String sort algorithm using random access iterators, wraps using default of unsigned char.
-  (All variants fall back to @c pdqsort if the data size is too small, < @c detail::min_sort_size).
-
-  \details @c string_sort is a fast templated in-place hybrid radix/comparison algorithm,
-which in testing tends to be roughly 50% to 2X faster than @c pdqsort for large tests (>=100kB).\n
-Worst-case performance is <em>  O(N * (lg(range)/s + s)) </em>,
-so @c integer_sort is asymptotically faster
-than pure comparison-based algorithms. @c s is @c max_splits, which defaults to 11,
-so its worst-case with default settings for 32-bit integers is
-<em> O(N * ((32/11) </em> slow radix-based iterations fast comparison-based iterations).\n\n
-Some performance plots of runtime vs. n and log(range) are provided:\n
-   <a href="../../doc/graph/windows_string_sort.htm"> windows_string_sort</a>
-   \n
-   <a href="../../doc/graph/osx_string_sort.htm"> osx_string_sort</a>
-
-   \param[in] first Iterator pointer to first element.
-   \param[in] last Iterator pointing to one beyond the end of data.
-
-   \pre [@c first, @c last) is a valid range.
-   \pre @c RandomAccessIter @c value_type is mutable.
-   \pre @c RandomAccessIter @c value_type is <a href="http://en.cppreference.com/w/cpp/concept/LessThanComparable">LessThanComparable</a>
-   \pre @c RandomAccessIter @c value_type supports the @c operator>>,
-   which returns an integer-type right-shifted a specified number of bits.
-   \post The elements in the range [@c first, @c last) are sorted in ascending order.
-
-   \throws std::exception Propagates exceptions if any of the element comparisons, the element swaps (or moves),
-   the right shift, subtraction of right-shifted elements, functors,
-   or any operations on iterators throw.
-
-   \warning Throwing an exception may cause data loss. This will also throw if a small vector resize throws, in which case there will be no data loss.
-   \warning Invalid arguments cause undefined behaviour.
-   \note @c spreadsort function provides a wrapper that calls the fastest sorting algorithm available for a data type,
-   enabling faster generic-programming.
-
-   \remark The lesser of <em> O(N*log(N)) </em> comparisons and <em> O(N*log(K/S + S)) </em>operations worst-case, where:
-   \remark  *  N is @c last - @c first,
-   \remark  *  K is the log of the range in bits (32 for 32-bit integers using their full range),
-   \remark  *  S is a constant called max_splits, defaulting to 11 (except for strings where it is the log of the character size).
-
-*/
-  template<class RandomAccessIter>
-  auto string_sort(RandomAccessIter first, RandomAccessIter last)
-      -> void
-  {
-    unsigned char unused = '\0';
-    string_sort(first, last, unused);
-  }
-
 
 /*! \brief String sort algorithm using random access iterators, allowing character-type overloads.
 
@@ -188,273 +137,18 @@ Some performance plots of runtime vs. n and log(range) are provided:\n
    \remark  *  K is the log of the range in bits (32 for 32-bit integers using their full range),
    \remark  *  S is a constant called max_splits, defaulting to 11 (except for strings where it is the log of the character size).
 */
-  template<class RandomAccessIter, class Compare, class Unsigned_char_type>
+  template<typename RandomAccessIter, typename Compare,
+           typename Projection, typename Unsigned_char_type>
   auto reverse_string_sort(RandomAccessIter first, RandomAccessIter last,
-                           Compare comp, Unsigned_char_type unused)
+                           Compare comp, Projection projection,
+                           Unsigned_char_type unused)
       -> void
   {
     //Don't sort if it's too small to optimize.
     if (last - first < detail::min_sort_size)
-      pdqsort(first, last, comp, utility::identity{});
+      pdqsort(first, last, comp, projection);
     else
-      detail::reverse_string_sort(first, last, unused);
-  }
-
-
-/*! \brief String sort algorithm using random access iterators,  wraps using default of @c unsigned char.
-
-  (All variants fall back to @c pdqsort if the data size is too small, < @c detail::min_sort_size).
-
-  \details @c integer_sort is a fast templated in-place hybrid radix/comparison algorithm,
-which in testing tends to be roughly 50% to 2X faster than @c pdqsort for large tests (>=100kB).\n
-Worst-case performance is <em>  O(N * (lg(range)/s + s)) </em>,
-so @c integer_sort is asymptotically faster
-than pure comparison-based algorithms. @c s is @c max_splits, which defaults to 11,
-so its worst-case with default settings for 32-bit integers is
-<em> O(N * ((32/11) </em> slow radix-based iterations fast comparison-based iterations).\n\n
-Some performance plots of runtime vs. n and log(range) are provided:\n
-   <a href="../../doc/graph/windows_integer_sort.htm"> windows_integer_sort</a>
-   \n
-   <a href="../../doc/graph/osx_integer_sort.htm"> osx_integer_sort</a>
-
-   \param[in] first Iterator pointer to first element.
-   \param[in] last Iterator pointing to one beyond the end of data.
-   \param[in] comp A binary functor that returns whether the first element passed to it should go before the second in order.
-
-   \pre [@c first, @c last) is a valid range.
-   \pre @c RandomAccessIter @c value_type is mutable.
-   \pre @c RandomAccessIter @c value_type is <a href="http://en.cppreference.com/w/cpp/concept/LessThanComparable">LessThanComparable</a>
-   \pre @c RandomAccessIter @c value_type supports the @c operator>>,
-   which returns an integer-type right-shifted a specified number of bits.
-   \post The elements in the range [@c first, @c last) are sorted in ascending order.
-
-   \return @c void.
-
-   \throws  std::exception Propagates exceptions if any of the element comparisons, the element swaps (or moves),
-   the right shift, subtraction of right-shifted elements, functors,
-   or any operations on iterators throw.
-
-   \warning Throwing an exception may cause data loss. This will also throw if a small vector resize throws, in which case there will be no data loss.
-   \warning Invalid arguments cause undefined behaviour.
-   \note @c spreadsort function provides a wrapper that calls the fastest sorting algorithm available for a data type,
-   enabling faster generic-programming.
-
-   \remark The lesser of <em> O(N*log(N)) </em> comparisons and <em> O(N*log(K/S + S)) </em>operations worst-case, where:
-   \remark  *  N is @c last - @c first,
-   \remark  *  K is the log of the range in bits (32 for 32-bit integers using their full range),
-   \remark  *  S is a constant called max_splits, defaulting to 11 (except for strings where it is the log of the character size).
-*/
-  template<class RandomAccessIter, class Compare>
-  auto reverse_string_sort(RandomAccessIter first,
-                           RandomAccessIter last, Compare comp)
-      -> void
-  {
-    unsigned char unused = '\0';
-    reverse_string_sort(first, last, comp, unused);
-  }
-
-
-/*! \brief String sort algorithm using random access iterators,  wraps using default of @c unsigned char.
-
-  (All variants fall back to @c pdqsort if the data size is too small, < @c detail::min_sort_size).
-
-  \details @c integer_sort is a fast templated in-place hybrid radix/comparison algorithm,
-which in testing tends to be roughly 50% to 2X faster than @c pdqsort for large tests (>=100kB).\n
-Worst-case performance is <em>  O(N * (lg(range)/s + s)) </em>,
-so @c integer_sort is asymptotically faster
-than pure comparison-based algorithms. @c s is @c max_splits, which defaults to 11,
-so its worst-case with default settings for 32-bit integers is
-<em> O(N * ((32/11) </em> slow radix-based iterations fast comparison-based iterations).\n\n
-Some performance plots of runtime vs. n and log(range) are provided:\n
-   <a href="../../doc/graph/windows_integer_sort.htm"> windows_integer_sort</a>
-   \n
-   <a href="../../doc/graph/osx_integer_sort.htm"> osx_integer_sort</a>
-
-   \param[in] first Iterator pointer to first element.
-   \param[in] last Iterator pointing to one beyond the end of data.
-   \param[in] getchar Bracket functor equivalent to @c operator[], taking a number corresponding to the character offset.
-   \param[in] length Functor to get the length of the string in characters.
-
-   \pre [@c first, @c last) is a valid range.
-   \pre @c RandomAccessIter @c value_type is mutable.
-   \pre @c RandomAccessIter @c value_type is <a href="http://en.cppreference.com/w/cpp/concept/LessThanComparable">LessThanComparable</a>
-   \pre @c RandomAccessIter @c value_type supports the @c operator>>,
-   which returns an integer-type right-shifted a specified number of bits.
-   \post The elements in the range [@c first, @c last) are sorted in ascending order.
-
-   \return @c void.
-
-   \throws  std::exception Propagates exceptions if any of the element comparisons, the element swaps (or moves),
-   the right shift, subtraction of right-shifted elements, functors,
-   or any operations on iterators throw.
-
-   \warning Throwing an exception may cause data loss. This will also throw if a small vector resize throws, in which case there will be no data loss.
-   \warning Invalid arguments cause undefined behaviour.
-   \note @c spreadsort function provides a wrapper that calls the fastest sorting algorithm available for a data type,
-   enabling faster generic-programming.
-
-   \remark The lesser of <em> O(N*log(N)) </em> comparisons and <em> O(N*log(K/S + S)) </em>operations worst-case, where:
-   \remark  *  N is @c last - @c first,
-   \remark  *  K is the log of the range in bits (32 for 32-bit integers using their full range),
-   \remark  *  S is a constant called max_splits, defaulting to 11 (except for strings where it is the log of the character size).
-
-*/
-  template<class RandomAccessIter, class Get_char, class Get_length>
-  auto string_sort(RandomAccessIter first, RandomAccessIter last,
-                   Get_char getchar, Get_length length)
-      -> void
-  {
-    //Don't sort if it's too small to optimize
-    if (last - first < detail::min_sort_size)
-      pdqsort(first, last, std::less<>{}, utility::identity{});
-    else {
-      //skipping past empties, which allows us to get the character type
-      //.empty() is not used so as not to require a user declaration of it
-      while (!length(*first)) {
-        if (++first == last)
-          return;
-      }
-      detail::string_sort(first, last, getchar, length, getchar((*first), 0));
-    }
-  }
-
-
-
-/*! \brief String sort algorithm using random access iterators,  wraps using default of @c unsigned char.
-
-  (All variants fall back to @c pdqsort if the data size is too small, < @c detail::min_sort_size).
-
-  \details @c integer_sort is a fast templated in-place hybrid radix/comparison algorithm,
-which in testing tends to be roughly 50% to 2X faster than @c pdqsort for large tests (>=100kB).\n
-Worst-case performance is <em>  O(N * (lg(range)/s + s)) </em>,
-so @c integer_sort is asymptotically faster
-than pure comparison-based algorithms. @c s is @c max_splits, which defaults to 11,
-so its worst-case with default settings for 32-bit integers is
-<em> O(N * ((32/11) </em> slow radix-based iterations fast comparison-based iterations).\n\n
-Some performance plots of runtime vs. n and log(range) are provided:\n
-   <a href="../../doc/graph/windows_integer_sort.htm"> windows_integer_sort</a>
-   \n
-   <a href="../../doc/graph/osx_integer_sort.htm"> osx_integer_sort</a>
-
-
-   \param[in] first Iterator pointer to first element.
-   \param[in] last Iterator pointing to one beyond the end of data.
-   \param[in] getchar Bracket functor equivalent to @c operator[], taking a number corresponding to the character offset.
-   \param[in] length Functor to get the length of the string in characters.
-   \param[in] comp A binary functor that returns whether the first element passed to it should go before the second in order.
-
-
-   \pre [@c first, @c last) is a valid range.
-   \pre @c RandomAccessIter @c value_type is mutable.
-   \pre @c RandomAccessIter @c value_type is <a href="http://en.cppreference.com/w/cpp/concept/LessThanComparable">LessThanComparable</a>
-   \post The elements in the range [@c first, @c last) are sorted in ascending order.
-
-   \return @c void.
-
-   \throws std::exception Propagates exceptions if any of the element comparisons, the element swaps (or moves),
-   the right shift, subtraction of right-shifted elements, functors,
-   or any operations on iterators throw.
-
-   \warning Throwing an exception may cause data loss. This will also throw if a small vector resize throws, in which case there will be no data loss.
-   \warning Invalid arguments cause undefined behaviour.
-   \note @c spreadsort function provides a wrapper that calls the fastest sorting algorithm available for a data type,
-   enabling faster generic-programming.
-
-   \remark The lesser of <em> O(N*log(N)) </em> comparisons and <em> O(N*log(K/S + S)) </em>operations worst-case, where:
-   \remark  *  N is @c last - @c first,
-   \remark  *  K is the log of the range in bits (32 for 32-bit integers using their full range),
-   \remark  *  S is a constant called max_splits, defaulting to 11 (except for strings where it is the log of the character size).
-
-*/
-  template<class RandomAccessIter, class Get_char, class Get_length,
-           class Compare>
-  auto string_sort(RandomAccessIter first, RandomAccessIter last,
-                   Get_char getchar, Get_length length, Compare comp)
-      -> void
-  {
-    //Don't sort if it's too small to optimize
-    if (last - first < detail::min_sort_size)
-      pdqsort(first, last, comp, utility::identity{});
-    else {
-      //skipping past empties, which allows us to get the character type
-      //.empty() is not used so as not to require a user declaration of it
-      while (!length(*first)) {
-        if (++first == last)
-          return;
-      }
-      detail::string_sort(first, last, getchar, length, comp,
-                          getchar((*first), 0));
-    }
-  }
-
-
-/*! \brief Reverse String sort algorithm using random access iterators.
-
-  (All variants fall back to @c pdqsort if the data size is too small, < @c detail::min_sort_size).
-
-  \details @c integer_sort is a fast templated in-place hybrid radix/comparison algorithm,
-which in testing tends to be roughly 50% to 2X faster than @c pdqsort for large tests (>=100kB).\n
-Worst-case performance is <em>  O(N * (lg(range)/s + s)) </em>,
-so @c integer_sort is asymptotically faster
-than pure comparison-based algorithms. @c s is @c max_splits, which defaults to 11,
-so its worst-case with default settings for 32-bit integers is
-<em> O(N * ((32/11) </em> slow radix-based iterations fast comparison-based iterations).\n\n
-Some performance plots of runtime vs. n and log(range) are provided:\n
-   <a href="../../doc/graph/windows_integer_sort.htm"> windows_integer_sort</a>
-   \n
-   <a href="../../doc/graph/osx_integer_sort.htm"> osx_integer_sort</a>
-
-
-   \param[in] first Iterator pointer to first element.
-   \param[in] last Iterator pointing to one beyond the end of data.
-   \param[in] getchar Bracket functor equivalent to @c operator[], taking a number corresponding to the character offset.
-   \param[in] length Functor to get the length of the string in characters.
-   \param[in] comp A binary functor that returns whether the first element passed to it should go before the second in order.
-
-
-   \pre [@c first, @c last) is a valid range.
-   \pre @c RandomAccessIter @c value_type is mutable.
-   \pre @c RandomAccessIter @c value_type is <a href="http://en.cppreference.com/w/cpp/concept/LessThanComparable">LessThanComparable</a>
-   \post The elements in the range [@c first, @c last) are sorted in ascending order.
-
-   \return @c void.
-
-   \throws std::exception Propagates exceptions if any of the element comparisons, the element swaps (or moves),
-   the right shift, subtraction of right-shifted elements, functors,
-   or any operations on iterators throw.
-
-   \warning Throwing an exception may cause data loss. This will also throw if a small vector resize throws, in which case there will be no data loss.
-   \warning Invalid arguments cause undefined behaviour.
-   \note @c spreadsort function provides a wrapper that calls the fastest sorting algorithm available for a data type,
-   enabling faster generic-programming.
-
-   \remark The lesser of <em> O(N*log(N)) </em> comparisons and <em> O(N*log(K/S + S)) </em>operations worst-case, where:
-   \remark  *  N is @c last - @c first,
-   \remark  *  K is the log of the range in bits (32 for 32-bit integers using their full range),
-   \remark  *  S is a constant called max_splits, defaulting to 11 (except for strings where it is the log of the character size).
-
-*/
-  template<class RandomAccessIter, class Get_char, class Get_length,
-           class Compare>
-  auto reverse_string_sort(RandomAccessIter first, RandomAccessIter last,
-                           Get_char getchar, Get_length length, Compare comp)
-      -> void
-  {
-    //Don't sort if it's too small to optimize
-    if (last - first < detail::min_sort_size)
-      pdqsort(first, last, comp, utility::identity{});
-    else {
-      //skipping past empties, which allows us to get the character type
-      //.empty() is not used so as not to require a user declaration of it
-      while (!length(*(--last))) {
-        //If there is just one non-empty at the beginning, this is sorted
-        if (first == last)
-          return;
-      }
-      //making last just after the end of the non-empty part of the array
-      detail::reverse_string_sort(first, last + 1, getchar, length, comp,
-                                  getchar((*last), 0));
-    }
+      detail::reverse_string_sort(first, last, projection, unused);
   }
 }}}
 

--- a/include/cpp-sort/sorters/spread_sorter/float_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/float_spread_sorter.h
@@ -32,6 +32,7 @@
 #include <limits>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/static_const.h>
 #include "../../detail/iterator_traits.h"
 #include "../../detail/spreadsort/float_sort.h"
@@ -45,17 +46,21 @@ namespace cppsort
     {
         struct float_spread_sorter_impl
         {
-            template<typename RandomAccessIterator>
-            auto operator()(RandomAccessIterator first, RandomAccessIterator last) const
+            template<
+                typename RandomAccessIterator,
+                typename Projection = utility::identity
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Projection projection={}) const
                 -> std::enable_if_t<
-                    std::numeric_limits<value_type_t<RandomAccessIterator>>::is_iec559 && (
-                        sizeof(value_type_t<RandomAccessIterator>) == sizeof(std::uint32_t) ||
-                        sizeof(value_type_t<RandomAccessIterator>) == sizeof(std::uint64_t)
-                    )
-
+                    std::numeric_limits<projected_t<RandomAccessIterator, Projection>>::is_iec559 && (
+                        sizeof(projected_t<RandomAccessIterator, Projection>) == sizeof(std::uint32_t) ||
+                        sizeof(projected_t<RandomAccessIterator, Projection>) == sizeof(std::uint64_t)
+                    ) &&
+                    is_projection_iterator_v<Projection, RandomAccessIterator>
                 >
             {
-                spreadsort::float_sort(first, last);
+                spreadsort::float_sort(first, last, projection);
             }
 
             ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/spread_sorter/integer_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/integer_spread_sorter.h
@@ -32,6 +32,8 @@
 #include <iterator>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/functional.h>
 #include <cpp-sort/utility/static_const.h>
 #include "../../detail/iterator_traits.h"
 #include "../../detail/spreadsort/integer_sort.h"
@@ -45,16 +47,21 @@ namespace cppsort
     {
         struct integer_spread_sorter_impl
         {
-            template<typename RandomAccessIterator>
-            auto operator()(RandomAccessIterator first, RandomAccessIterator last) const
+            template<
+                typename RandomAccessIterator,
+                typename Projection = utility::identity
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Projection projection={}) const
                 -> std::enable_if_t<
-                    std::is_integral<value_type_t<RandomAccessIterator>>::value && (
-                        sizeof(value_type_t<RandomAccessIterator>) <= sizeof(std::size_t) ||
-                        sizeof(value_type_t<RandomAccessIterator>) <= sizeof(std::uintmax_t)
-                    )
+                    std::is_integral<projected_t<RandomAccessIterator, Projection>>::value && (
+                        sizeof(projected_t<RandomAccessIterator, Projection>) <= sizeof(std::size_t) ||
+                        sizeof(projected_t<RandomAccessIterator, Projection>) <= sizeof(std::uintmax_t)
+                    ) &&
+                    is_projection_iterator_v<Projection, RandomAccessIterator>
                 >
             {
-                spreadsort::integer_sort(first, last);
+                spreadsort::integer_sort(first, last, projection);
             }
 
             ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/sorters/spread_sorter/string_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/string_spread_sorter.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/utility/functional.h>
 #include <cpp-sort/utility/static_const.h>
 #include "../../detail/iterator_traits.h"
 #include "../../detail/spreadsort/string_sort.h"
@@ -49,49 +50,75 @@ namespace cppsort
             ////////////////////////////////////////////////////////////
             // Ascending string sort
 
-            template<typename RandomAccessIterator>
-            auto operator()(RandomAccessIterator first, RandomAccessIterator last) const
+            template<
+                typename RandomAccessIterator,
+                typename Projection = utility::identity
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Projection projection={}) const
                 -> std::enable_if_t<
-                    std::is_same<value_type_t<RandomAccessIterator>, std::string>::value
+                    std::is_same<
+                        projected_t<RandomAccessIterator, Projection>,
+                        std::string
+                    >::value
                 >
             {
-                spreadsort::string_sort(first, last);
+                unsigned char unused = '\0';
+                spreadsort::string_sort(first, last, projection, unused);
             }
 
-            template<typename RandomAccessIterator>
-            auto operator()(RandomAccessIterator first, RandomAccessIterator last) const
+            template<
+                typename RandomAccessIterator,
+                typename Projection = utility::identity
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Projection projection={}) const
                 -> std::enable_if_t<
-                    std::is_same<value_type_t<RandomAccessIterator>, std::wstring>::value
-                    && (sizeof(wchar_t) == 2)
+                    std::is_same<
+                        projected_t<RandomAccessIterator, Projection>,
+                        std::wstring
+                    >::value && (sizeof(wchar_t) == 2)
                 >
             {
                 std::uint16_t unused = 0;
-                spreadsort::string_sort(first, last, unused);
+                spreadsort::string_sort(first, last, projection, unused);
             }
 
             ////////////////////////////////////////////////////////////
             // Descending string sort
 
-            template<typename RandomAccessIterator>
+            template<
+                typename RandomAccessIterator,
+                typename Projection = utility::identity
+            >
             auto operator()(RandomAccessIterator first, RandomAccessIterator last,
-                            std::greater<> compare) const
+                            std::greater<> compare, Projection projection={}) const
                 -> std::enable_if_t<
-                    std::is_same<value_type_t<RandomAccessIterator>, std::string>::value
+                    std::is_same<
+                        projected_t<RandomAccessIterator, Projection>,
+                        std::string
+                    >::value
                 >
             {
-                spreadsort::reverse_string_sort(first, last, compare);
+                unsigned char unused = '\0';
+                spreadsort::reverse_string_sort(first, last, compare, projection, unused);
             }
 
-            template<typename RandomAccessIterator>
+            template<
+                typename RandomAccessIterator,
+                typename Projection = utility::identity
+            >
             auto operator()(RandomAccessIterator first, RandomAccessIterator last,
-                            std::greater<> compare) const
+                            std::greater<> compare, Projection projection={}) const
                 -> std::enable_if_t<
-                    std::is_same<value_type_t<RandomAccessIterator>, std::wstring>::value
-                    && (sizeof(wchar_t) == 2)
+                    std::is_same<
+                        projected_t<RandomAccessIterator, Projection>,
+                        std::wstring
+                    >::value && (sizeof(wchar_t) == 2)
                 >
             {
                 std::uint16_t unused = 0;
-                spreadsort::reverse_string_sort(first, last, compare, unused);
+                spreadsort::reverse_string_sort(first, last, compare, projection, unused);
             }
 
             ////////////////////////////////////////////////////////////

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -45,6 +45,7 @@ set(
     sorters/merge_sorter_projection.cpp
     sorters/spread_sorter.cpp
     sorters/spread_sorter_defaults.cpp
+    sorters/spread_sorter_projection.cpp
 )
 
 set(

--- a/testsuite/adapters/schwartz_adapter_every_sorter.cpp
+++ b/testsuite/adapters/schwartz_adapter_every_sorter.cpp
@@ -25,6 +25,7 @@
 #include <ctime>
 #include <iterator>
 #include <random>
+#include <string>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/adapters/schwartz_adapter.h>
@@ -33,13 +34,20 @@
 #include <cpp-sort/utility/buffer.h>
 #include "../algorithm.h"
 
+namespace
+{
+    template<typename T=double>
+    struct wrapper
+    {
+        T value;
+    };
+}
+
 TEST_CASE( "every sorter with Schwartzian transform adapter",
            "[schwartz_adapter]" )
 {
-    struct wrapper { double value; };
-
-    std::vector<wrapper> collection(412);
-    helpers::iota(std::begin(collection), std::end(collection), -125, &wrapper::value);
+    std::vector<wrapper<>> collection(412);
+    helpers::iota(std::begin(collection), std::end(collection), -125, &wrapper<>::value);
     std::mt19937 engine(std::time(nullptr));
     std::shuffle(std::begin(collection), std::end(collection), engine);
 
@@ -50,112 +58,141 @@ TEST_CASE( "every sorter with Schwartzian transform adapter",
         using sorter = schwartz_adapter<block_sorter<
             utility::fixed_buffer<0>
         >>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "default_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::default_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "grail_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::grail_sorter<>>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "heap_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::heap_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "insertion_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::insertion_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "merge_insertion_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::merge_insertion_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "merge_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::merge_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "pdq_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::pdq_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "poplar_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::poplar_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "quick_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::quick_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "selection_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::selection_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "smooth_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::smooth_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        using sorter = cppsort::schwartz_adapter<cppsort::spread_sorter>;
+
+        std::vector<wrapper<int>> collection2(412);
+        helpers::iota(std::begin(collection2), std::end(collection2), -125, &wrapper<int>::value);
+        std::vector<wrapper<std::string>> collection3;
+        for (int i = -125 ; i < 287 ; ++i) { collection3.push_back({std::to_string(i)}); }
+
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
+        CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
+                                  std::less<>{}, &wrapper<>::value) );
+
+        std::shuffle(std::begin(collection2), std::end(collection2), engine);
+        cppsort::sort(sorter{}, collection2, &wrapper<int>::value);
+        CHECK( helpers::is_sorted(std::begin(collection2), std::end(collection2),
+                                  std::less<>{}, &wrapper<int>::value) );
+
+        std::shuffle(std::begin(collection3), std::end(collection3), engine);
+        cppsort::sort(sorter{}, collection3, &wrapper<std::string>::value);
+        CHECK( helpers::is_sorted(std::begin(collection3), std::end(collection3),
+                                  std::less<>{}, &wrapper<std::string>::value) );
+
+        std::shuffle(std::begin(collection3), std::end(collection3), engine);
+        cppsort::sort(sorter{}, collection3, std::greater<>{}, &wrapper<std::string>::value);
+        CHECK( helpers::is_sorted(std::begin(collection3), std::end(collection3),
+                                  std::greater<>{}, &wrapper<std::string>::value) );
     }
 
     SECTION( "tim_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::tim_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 
     SECTION( "verge_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::verge_sorter>;
-        cppsort::sort(sorter{}, collection, &wrapper::value);
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
-                                  std::less<>{}, &wrapper::value) );
+                                  std::less<>{}, &wrapper<>::value) );
     }
 }

--- a/testsuite/sorters/spread_sorter_projection.cpp
+++ b/testsuite/sorters/spread_sorter_projection.cpp
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <ctime>
+#include <iterator>
+#include <random>
+#include <utility>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sorters/spread_sorter.h>
+#include <cpp-sort/sort.h>
+#include "../algorithm.h"
+
+TEST_CASE( "spread_sorter tests with projections",
+           "[spread_sorter][projection]" )
+{
+    // Pseudo-random number engine
+    std::mt19937_64 engine(std::time(nullptr));
+
+    SECTION( "sort with int iterable" )
+    {
+        std::vector<std::pair<int, float>> vec;
+        for (int i = 0 ; i < 100'000 ; ++i)
+        {
+            vec.emplace_back(i, i);
+        }
+        std::shuffle(std::begin(vec), std::end(vec), engine);
+        cppsort::sort(cppsort::spread_sorter{}, vec,
+                      &std::pair<int, float>::first);
+        CHECK( helpers::is_sorted(std::begin(vec), std::end(vec),
+                                  std::less<>{}, &std::pair<int, float>::second) );
+    }
+
+    SECTION( "sort with unsigned int iterators" )
+    {
+        std::vector<std::pair<unsigned, float>> vec;
+        for (int i = 0 ; i < 100'000 ; ++i)
+        {
+            vec.emplace_back(i, i);
+        }
+        std::shuffle(std::begin(vec), std::end(vec), engine);
+        cppsort::sort(cppsort::spread_sorter{}, vec,
+                      &std::pair<unsigned, float>::first);
+        CHECK( helpers::is_sorted(std::begin(vec), std::end(vec),
+                                  std::less<>{}, &std::pair<unsigned, float>::second) );
+    }
+}

--- a/testsuite/sorters/spread_sorter_projection.cpp
+++ b/testsuite/sorters/spread_sorter_projection.cpp
@@ -23,6 +23,7 @@
  */
 #include <algorithm>
 #include <ctime>
+#include <functional>
 #include <iterator>
 #include <random>
 #include <utility>
@@ -92,5 +93,35 @@ TEST_CASE( "spread_sorter tests with projections",
                       &std::pair<int, double>::second);
         CHECK( helpers::is_sorted(std::begin(vec), std::end(vec),
                                   std::less<>{}, &std::pair<int, double>::first) );
+    }
+
+    SECTION( "sort with std::string iterators" )
+    {
+        struct wrapper { std::string value; };
+
+        std::vector<wrapper> vec;
+        for (int i = 0 ; i < 100'000 ; ++i)
+        {
+            vec.push_back({std::to_string(i)});
+        }
+        std::shuffle(std::begin(vec), std::end(vec), engine);
+        cppsort::sort(cppsort::spread_sorter{}, vec, &wrapper::value);
+        CHECK( helpers::is_sorted(std::begin(vec), std::end(vec),
+                                  std::less<>{}, &wrapper::value) );
+    }
+
+    SECTION( "reverse sort with std::string iterators" )
+    {
+        struct wrapper { std::string value; };
+
+        std::vector<wrapper> vec;
+        for (int i = 0 ; i < 100'000 ; ++i)
+        {
+            vec.push_back({std::to_string(i)});
+        }
+        std::shuffle(std::begin(vec), std::end(vec), engine);
+        cppsort::sort(cppsort::spread_sorter{}, vec, std::greater<>{}, &wrapper::value);
+        CHECK( helpers::is_sorted(std::begin(vec), std::end(vec),
+                                  std::greater<>{}, &wrapper::value) );
     }
 }

--- a/testsuite/sorters/spread_sorter_projection.cpp
+++ b/testsuite/sorters/spread_sorter_projection.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2016 Morwenn
+ * Copyright (c) 2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/testsuite/sorters/spread_sorter_projection.cpp
+++ b/testsuite/sorters/spread_sorter_projection.cpp
@@ -65,4 +65,32 @@ TEST_CASE( "spread_sorter tests with projections",
         CHECK( helpers::is_sorted(std::begin(vec), std::end(vec),
                                   std::less<>{}, &std::pair<unsigned, float>::second) );
     }
+
+    SECTION( "sort with float iterable" )
+    {
+        std::vector<std::pair<int, float>> vec;
+        for (int i = 0 ; i < 100'000 ; ++i)
+        {
+            vec.emplace_back(i, i);
+        }
+        std::shuffle(std::begin(vec), std::end(vec), engine);
+        cppsort::sort(cppsort::spread_sorter{}, vec,
+                      &std::pair<int, float>::second);
+        CHECK( helpers::is_sorted(std::begin(vec), std::end(vec),
+                                  std::less<>{}, &std::pair<int, float>::first) );
+    }
+
+    SECTION( "sort with double iterators" )
+    {
+        std::vector<std::pair<int, double>> vec;
+        for (int i = 0 ; i < 100'000 ; ++i)
+        {
+            vec.emplace_back(i, i);
+        }
+        std::shuffle(std::begin(vec), std::end(vec), engine);
+        cppsort::sort(cppsort::spread_sorter{}, vec,
+                      &std::pair<int, double>::second);
+        CHECK( helpers::is_sorted(std::begin(vec), std::end(vec),
+                                  std::less<>{}, &std::pair<int, double>::first) );
+    }
 }


### PR DESCRIPTION
This branch acknowledges the fact that non-comparison sorters may still be able to handle projections too as long as the information about the items of the collection to sort is not discarded by the algorithm and the original sorter can handle the resulting type of the projection.

Acknowledging that fact is fun and all, but the branch also brings projection support for every flavour of `spread_sorter`, and also enchances `schwartz_adapter` so that it properly handles projection-only sorters. There is also a huge removal of unused functions in the source code of `spread_sorter`.