### PR TITLE
Support for temporary span-like classes. Fixes #70.

### DIFF
--- a/examples/bubble_sorter.cpp
+++ b/examples/bubble_sorter.cpp
@@ -27,6 +27,7 @@
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/begin_end.h>
 #include <cpp-sort/utility/iter_move.h>
 #include <cpp-sort/utility/size.h>
 #include <cpp-sort/utility/static_const.h>
@@ -94,7 +95,7 @@ namespace detail
                 StrictWeakOrdering, ForwardIterable
             >>
         >
-        auto operator()(ForwardIterable& iterable, StrictWeakOrdering compare={}) const
+        auto operator()(ForwardIterable&& iterable, StrictWeakOrdering compare={}) const
             -> void
         {
             static_assert(
@@ -105,7 +106,7 @@ namespace detail
                 "bubble_sorter requires at least forward iterators"
             );
 
-            bubble_sort(std::begin(iterable),
+            bubble_sort(cppsort::utility::begin(iterable),
                         cppsort::utility::size(iterable),
                         compare);
         }

--- a/include/cpp-sort/adapters/counting_adapter.h
+++ b/include/cpp-sort/adapters/counting_adapter.h
@@ -55,11 +55,11 @@ namespace cppsort
                     not is_projection_v<Compare, Iterable>
                 >
             >
-            auto operator()(Iterable& iterable, Compare compare={}) const
+            auto operator()(Iterable&& iterable, Compare compare={}) const
                 -> CountType
             {
                 comparison_counter<Compare, CountType> cmp(compare);
-                ComparisonSorter{}(iterable, cmp);
+                ComparisonSorter{}(std::forward<Iterable>(iterable), cmp);
                 return cmp.count;
             }
 
@@ -86,12 +86,12 @@ namespace cppsort
                     is_projection_v<Projection, Iterable, Compare>
                 >
             >
-            auto operator()(Iterable& iterable, Compare compare={},
+            auto operator()(Iterable&& iterable, Compare compare={},
                             Projection projection={}) const
                 -> CountType
             {
                 comparison_counter<Compare, CountType> cmp(compare);
-                ComparisonSorter{}(iterable, cmp, projection);
+                ComparisonSorter{}(std::forward<Iterable>(iterable), cmp, projection);
                 return cmp.count;
             }
 

--- a/include/cpp-sort/adapters/hybrid_adapter.h
+++ b/include/cpp-sort/adapters/hybrid_adapter.h
@@ -145,14 +145,14 @@ namespace cppsort
             public:
 
                 template<typename Iterable, typename... Args>
-                auto operator()(Iterable& iterable, Args&&... args) const
+                auto operator()(Iterable&& iterable, Args&&... args) const
                     -> decltype(dispatch_sorter{}(
                         choice<
                             iterator_category_value<
                                 iterator_category_t<decltype(std::begin(iterable))>
                             > * categories_number
                         >{},
-                        iterable,
+                        std::forward<Iterable>(iterable),
                         std::forward<Args>(args)...
                     ))
                 {

--- a/include/cpp-sort/adapters/self_sort_adapter.h
+++ b/include/cpp-sort/adapters/self_sort_adapter.h
@@ -66,10 +66,10 @@ namespace cppsort
                 typename... Args,
                 typename = std::enable_if_t<has_sort_method<Iterable, Args...>>
             >
-            auto operator()(Iterable& iterable, Args&&... args) const
-                -> decltype(iterable.sort(std::forward<Args>(args)...))
+            auto operator()(Iterable&& iterable, Args&&... args) const
+                -> decltype(std::forward<Iterable>(iterable).sort(std::forward<Args>(args)...))
             {
-                return iterable.sort(std::forward<Args>(args)...);
+                return std::forward<Iterable>(iterable).sort(std::forward<Args>(args)...);
             }
 
             template<
@@ -78,10 +78,10 @@ namespace cppsort
                 typename = std::enable_if_t<not has_sort_method<Iterable, Args...>>,
                 typename = void // dummy parameter for ODR
             >
-            auto operator()(Iterable& iterable, Args&&... args) const
-                -> decltype(Sorter{}(iterable, std::forward<Args>(args)...))
+            auto operator()(Iterable&& iterable, Args&&... args) const
+                -> decltype(Sorter{}(std::forward<Iterable>(iterable), std::forward<Args>(args)...))
             {
-                return Sorter{}(iterable, std::forward<Args>(args)...);
+                return Sorter{}(std::forward<Iterable>(iterable), std::forward<Args>(args)...);
             }
 
             template<typename Iterator, typename... Args>

--- a/include/cpp-sort/detail/begin_end.h
+++ b/include/cpp-sort/detail/begin_end.h
@@ -1,0 +1,347 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2014
+//  Modified in 2016 by Morwenn for inclusion into cpp-sort
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef CPPSORT_DETAIL_BEGIN_END_H_
+#define CPPSORT_DETAIL_BEGIN_END_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <type_traits>
+#include <cpp-sort/utility/static_const.h>
+
+namespace cppsort
+{
+namespace detail
+{
+    namespace adl_begin_end_detail
+    {
+        struct begin_fn;
+        struct end_fn;
+        struct cbegin_fn;
+        struct cend_fn;
+        struct rbegin_fn;
+        struct rend_fn;
+        struct crbegin_fn;
+        struct crend_fn;
+    }
+
+    using adl_begin_end_detail::begin_fn;
+    using adl_begin_end_detail::end_fn;
+    using adl_begin_end_detail::cbegin_fn;
+    using adl_begin_end_detail::cend_fn;
+    using adl_begin_end_detail::rbegin_fn;
+    using adl_begin_end_detail::rend_fn;
+    using adl_begin_end_detail::crbegin_fn;
+    using adl_begin_end_detail::crend_fn;
+
+    namespace adl_begin_end_detail
+    {
+        using std::begin;
+        using std::end;
+
+        // A reference-wrapped Range is an Range
+        template<typename T>
+        auto begin(std::reference_wrapper<T> ref)
+            -> decltype(begin(ref.get()))
+        {
+            return begin(ref.get());
+        }
+
+        template<typename T>
+        auto end(std::reference_wrapper<T> ref)
+            -> decltype(end(ref.get()))
+        {
+            return end(ref.get());
+        }
+
+        template<typename T>
+        auto rbegin(std::reference_wrapper<T> ref)
+            -> decltype(rbegin(ref.get()))
+        {
+            return rbegin(ref.get());
+        }
+
+        template<typename T>
+        auto rend(std::reference_wrapper<T> ref)
+            -> decltype(rend(ref.get()))
+        {
+            return rend(ref.get());
+        }
+
+        struct begin_fn
+        {
+        private:
+            template<typename Rng>
+            static constexpr auto impl(Rng&& rng, long)
+                noexcept(noexcept(begin(static_cast<Rng&&>(rng))))
+                -> decltype(begin(static_cast<Rng&&>(rng)))
+            {
+                return begin(static_cast<Rng&&>(rng));
+            }
+
+            template<
+                typename Rng,
+                typename = std::enable_if_t<std::is_lvalue_reference<Rng>::value>
+            >
+            static constexpr auto impl(Rng&& rng, int)
+                noexcept(noexcept(rng.begin()))
+                -> decltype(rng.begin())
+            {
+                return rng.begin();
+            }
+
+        public:
+            template<typename Rng>
+            constexpr auto operator()(Rng&& rng) const
+                noexcept(noexcept(begin_fn::impl(static_cast<Rng&&>(rng), 0)))
+                -> std::decay_t<decltype(begin_fn::impl(static_cast<Rng&&>(rng), 0))>
+            {
+                return begin_fn::impl(static_cast<Rng&&>(rng), 0);
+            }
+        };
+
+        struct end_fn
+        {
+        private:
+            template<typename Rng>
+            static constexpr auto impl(Rng&& rng, long)
+                noexcept(noexcept(end(static_cast<Rng&&>(rng))))
+                -> decltype(end(static_cast<Rng&&>(rng)))
+            {
+                return end(static_cast<Rng&&>(rng));
+            }
+
+            template<
+                typename Rng,
+                typename = std::enable_if_t<std::is_lvalue_reference<Rng>::value>
+            >
+            static constexpr auto impl(Rng&& rng, int)
+                noexcept(noexcept(rng.end()))
+                -> decltype(rng.end())
+            {
+                return rng.end();
+            }
+
+        public:
+            template<typename Rng>
+            constexpr auto operator()(Rng&& rng) const
+                noexcept(noexcept(end_fn::impl(static_cast<Rng&&>(rng), 0)))
+                -> std::decay_t<decltype(end_fn::impl(static_cast<Rng&&>(rng), 0))>
+            {
+                return end_fn::impl(static_cast<Rng&&>(rng), 0);
+            }
+        };
+
+        struct rbegin_fn
+        {
+        private:
+            template<typename Rng>
+            static constexpr auto impl(Rng&& rng, long)
+                noexcept(noexcept(rbegin(static_cast<Rng&&>(rng))))
+                -> decltype(rbegin(static_cast<Rng&&>(rng)))
+            {
+                return rbegin(static_cast<Rng&&>(rng));
+            }
+
+            template<
+                typename Rng,
+                typename = std::enable_if_t<std::is_lvalue_reference<Rng>::value>
+            >
+            static constexpr auto impl(Rng&& rng, int)
+                noexcept(noexcept(rng.rbegin()))
+                -> decltype(rng.rbegin())
+            {
+                return rng.rbegin();
+            }
+
+        public:
+            template<typename Rng>
+            constexpr auto operator()(Rng&& rng) const
+                noexcept(noexcept(rbegin_fn::impl(static_cast<Rng&&>(rng), 0)))
+                -> std::decay_t<decltype(rbegin_fn::impl(static_cast<Rng&&>(rng), 0))>
+            {
+                return rbegin_fn::impl(static_cast<Rng&&>(rng), 0);
+            }
+
+            template<typename T, std::size_t N>
+            constexpr auto operator()(T (&t)[N]) const noexcept
+                -> std::reverse_iterator<T*>
+            {
+                return std::reverse_iterator<T*>(t + N);
+            }
+
+            template<typename T>
+            constexpr auto operator()(std::initializer_list<T> il) const noexcept
+                -> std::reverse_iterator<T const*>
+            {
+                return std::reverse_iterator<T const*>(il.end());
+            }
+        };
+
+        struct rend_fn
+        {
+        private:
+            template<typename Rng>
+            static constexpr auto impl(Rng&& rng, long)
+                noexcept(noexcept(rend(static_cast<Rng&&>(rng))))
+                -> decltype(rend(static_cast<Rng&&>(rng)))
+            {
+                return rend(static_cast<Rng&&>(rng));
+            }
+
+            template<
+                typename Rng,
+                typename = std::enable_if_t<std::is_lvalue_reference<Rng>::value>
+            >
+            static constexpr auto impl(Rng&& rng, int)
+                noexcept(noexcept(rng.rend()))
+                -> decltype(rng.rend())
+            {
+                return rng.rend();
+            }
+        public:
+            template<typename Rng>
+            constexpr auto operator()(Rng&& rng) const
+                noexcept(noexcept(rend_fn::impl(static_cast<Rng&&>(rng), 0)))
+                -> std::decay_t<decltype(rend_fn::impl(static_cast<Rng&&>(rng), 0))>
+            {
+                return rend_fn::impl(static_cast<Rng&&>(rng), 0);
+            }
+
+            template<typename T, std::size_t N>
+            constexpr auto operator()(T (&t)[N]) const noexcept
+                -> std::reverse_iterator<T*>
+            {
+                return std::reverse_iterator<T*>(t);
+            }
+            template<typename T>
+            constexpr auto operator()(std::initializer_list<T> il) const noexcept
+                -> std::reverse_iterator<T const*>
+            {
+                return std::reverse_iterator<T const*>(il.begin());
+            }
+        };
+
+        struct cbegin_fn
+        {
+            template<typename Rng>
+            constexpr auto operator()(const Rng& rng) const
+                noexcept(noexcept(utility::static_const<begin_fn>::value(rng)))
+                -> decltype(utility::static_const<begin_fn>::value(rng))
+            {
+                return utility::static_const<begin_fn>::value(rng);
+            }
+        };
+
+        struct cend_fn
+        {
+            template<typename Rng>
+            constexpr auto operator()(const Rng& rng) const
+                noexcept(noexcept(utility::static_const<end_fn>::value(rng)))
+                -> decltype(utility::static_const<end_fn>::value(rng))
+            {
+                return utility::static_const<end_fn>::value(rng);
+            }
+        };
+
+        struct crbegin_fn
+        {
+            template<typename Rng>
+            constexpr auto operator()(const Rng& rng) const
+                noexcept(noexcept(utility::static_const<rbegin_fn>::value(rng)))
+                -> decltype(utility::static_const<rbegin_fn>::value(rng))
+            {
+                return utility::static_const<rbegin_fn>::value(rng);
+            }
+        };
+
+        struct crend_fn
+        {
+            template<typename Rng>
+            constexpr auto operator()(const Rng& rng) const
+                noexcept(noexcept(utility::static_const<rend_fn>::value(rng)))
+                -> decltype(utility::static_const<rend_fn>::value(rng))
+            {
+                return utility::static_const<rend_fn>::value(rng);
+            }
+        };
+    }
+
+    /// \ingroup group-core
+    /// \return The result of an unqualified call to the `begin` free function
+    namespace
+    {
+        constexpr auto&& begin = utility::static_const<begin_fn>::value;
+    }
+
+    /// \ingroup group-core
+    /// \return The result of an unqualified call to the `end` free function
+    namespace
+    {
+        constexpr auto&& end = utility::static_const<end_fn>::value;
+    }
+
+    /// \ingroup group-core
+    /// \return The result of an unqualified call to the `begin` free function
+    /// with a const-qualified argument.
+    namespace
+    {
+        constexpr auto&& cbegin = utility::static_const<cbegin_fn>::value;
+    }
+
+    /// \ingroup group-core
+    /// \return The result of an unqualified call to the `end` free function
+    /// with a const-qualified argument.
+    namespace
+    {
+        constexpr auto&& cend = utility::static_const<cend_fn>::value;
+    }
+
+    /// \ingroup group-core
+    /// \return The result of an unqualified call to the `rbegin` free function
+    namespace
+    {
+        constexpr auto&& rbegin = utility::static_const<rbegin_fn>::value;
+    }
+
+    /// \ingroup group-core
+    /// \return The result of an unqualified call to the `rend` free function
+    namespace
+    {
+        constexpr auto&& rend = utility::static_const<rend_fn>::value;
+    }
+
+    /// \ingroup group-core
+    /// \return The result of an unqualified call to the `rbegin` free function
+    /// with a const-qualified argument.
+    namespace
+    {
+        constexpr auto&& crbegin = utility::static_const<crbegin_fn>::value;
+    }
+
+    /// \ingroup group-core
+    /// \return The result of an unqualified call to the `rend` free function
+    /// with a const-qualified argument.
+    namespace
+    {
+        constexpr auto&& crend = utility::static_const<crend_fn>::value;
+    }
+}}
+
+#endif // CPPSORT_DETAIL_BEGIN_END_H_

--- a/include/cpp-sort/sort.h
+++ b/include/cpp-sort/sort.h
@@ -28,6 +28,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <type_traits>
+#include <utility>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/sorters/default_sorter.h>
 
@@ -37,10 +38,10 @@ namespace cppsort
     // With default_sorter
 
     template<typename Iterable>
-    auto sort(Iterable& iterable)
+    auto sort(Iterable&& iterable)
         -> void
     {
-        default_sorter{}(iterable);
+        default_sorter{}(std::forward<Iterable>(iterable));
     }
 
     template<
@@ -48,10 +49,10 @@ namespace cppsort
         typename Compare,
         typename = std::enable_if_t<not is_sorter_v<Iterable, Compare>>
     >
-    auto sort(Iterable& iterable, Compare compare)
+    auto sort(Iterable&& iterable, Compare compare)
         -> void
     {
-        default_sorter{}(iterable, compare);
+        default_sorter{}(std::forward<Iterable>(iterable), compare);
     }
 
     template<
@@ -60,13 +61,14 @@ namespace cppsort
         typename Projection,
         typename = std::enable_if_t<
             not is_comparison_sorter_v<Iterable, Compare, Projection> &&
-            not is_projection_sorter_v<Iterable, Compare, Projection>
+            not is_projection_sorter_v<Iterable, Compare, Projection> &&
+            not is_sorter_iterator_v<Iterable, Compare>
         >
     >
-    auto sort(Iterable& iterable, Compare compare, Projection projection)
+    auto sort(Iterable&& iterable, Compare compare, Projection projection)
         -> void
     {
-        default_sorter{}(iterable, compare, projection);
+        default_sorter{}(std::forward<Iterable>(iterable), compare, projection);
     }
 
     template<typename Iterator>
@@ -110,10 +112,10 @@ namespace cppsort
         typename Iterable,
         typename = std::enable_if_t<is_sorter_v<Sorter, Iterable>>
     >
-    auto sort(const Sorter& sorter, Iterable& iterable)
+    auto sort(const Sorter& sorter, Iterable&& iterable)
         -> decltype(auto)
     {
-        return sorter(iterable);
+        return sorter(std::forward<Iterable>(iterable));
     }
 
     template<
@@ -125,10 +127,10 @@ namespace cppsort
             is_projection_sorter_v<Sorter, Iterable, Func>
         >
     >
-    auto sort(const Sorter& sorter, Iterable& iterable, Func func)
+    auto sort(const Sorter& sorter, Iterable&& iterable, Func func)
         -> decltype(auto)
     {
-        return sorter(iterable, func);
+        return sorter(std::forward<Iterable>(iterable), func);
     }
 
     template<
@@ -137,11 +139,11 @@ namespace cppsort
         typename Compare,
         typename Projection
     >
-    auto sort(const Sorter& sorter, Iterable& iterable,
+    auto sort(const Sorter& sorter, Iterable&& iterable,
               Compare compare, Projection projection)
         -> decltype(auto)
     {
-        return sorter(iterable, compare, projection);
+        return sorter(std::forward<Iterable>(iterable), compare, projection);
     }
 
     template<

--- a/include/cpp-sort/sorter_facade.h
+++ b/include/cpp-sort/sorter_facade.h
@@ -32,8 +32,8 @@
 #include <type_traits>
 #include <utility>
 #include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/begin_end.h>
 #include <cpp-sort/utility/functional.h>
-#include "detail/begin_end.h"
 #include "detail/projection_compare.h"
 
 namespace cppsort
@@ -186,10 +186,10 @@ namespace cppsort
             auto operator()(Iterable&& iterable) const
                 -> std::enable_if_t<
                     not detail::has_sort<Sorter, Iterable>::value,
-                    decltype(Sorter::operator()(detail::begin(iterable), detail::end(iterable)))
+                    decltype(Sorter::operator()(utility::begin(iterable), utility::end(iterable)))
                 >
             {
-                return Sorter::operator()(detail::begin(iterable), detail::end(iterable));
+                return Sorter::operator()(utility::begin(iterable), utility::end(iterable));
             }
 
             ////////////////////////////////////////////////////////////
@@ -219,11 +219,11 @@ namespace cppsort
             auto operator()(Iterable&& iterable, Compare compare) const
                 -> std::enable_if_t<
                     not detail::has_comparison_sort<Sorter, Iterable, Compare>::value &&
-                    detail::has_comparison_sort_iterator<Sorter, decltype(detail::begin(iterable)), Compare>::value,
-                    decltype(Sorter::operator()(detail::begin(iterable), detail::end(iterable), compare))
+                    detail::has_comparison_sort_iterator<Sorter, decltype(utility::begin(iterable)), Compare>::value,
+                    decltype(Sorter::operator()(utility::begin(iterable), utility::end(iterable), compare))
                 >
             {
-                return Sorter::operator()(detail::begin(iterable), detail::end(iterable), compare);
+                return Sorter::operator()(utility::begin(iterable), utility::end(iterable), compare);
             }
 
             ////////////////////////////////////////////////////////////
@@ -276,11 +276,11 @@ namespace cppsort
                 -> std::enable_if_t<
                     not detail::has_projection_sort<Sorter, Iterable, Projection>::value &&
                     not detail::has_comparison_projection_sort<Sorter, Iterable, std::less<>, Projection>::value &&
-                        detail::has_projection_sort_iterator<Sorter, decltype(detail::begin(iterable)), Projection>::value,
-                    decltype(Sorter::operator()(detail::begin(iterable), detail::end(iterable), projection))
+                        detail::has_projection_sort_iterator<Sorter, decltype(utility::begin(iterable)), Projection>::value,
+                    decltype(Sorter::operator()(utility::begin(iterable), utility::end(iterable), projection))
                 >
             {
-                return Sorter::operator()(detail::begin(iterable), detail::end(iterable), projection);
+                return Sorter::operator()(utility::begin(iterable), utility::end(iterable), projection);
             }
 
             template<typename Iterable, typename Projection>
@@ -288,17 +288,17 @@ namespace cppsort
                 -> std::enable_if_t<
                     not detail::has_projection_sort<Sorter, Iterable, Projection>::value &&
                     not detail::has_comparison_projection_sort<Sorter, Iterable, std::less<>, Projection>::value &&
-                    not detail::has_projection_sort_iterator<Sorter, decltype(detail::begin(iterable)), Projection>::value &&
+                    not detail::has_projection_sort_iterator<Sorter, decltype(utility::begin(iterable)), Projection>::value &&
                         detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         std::less<>,
                         Projection
                     >::value,
-                    decltype(Sorter::operator()(detail::begin(iterable), detail::end(iterable), std::less<>{}, projection))
+                    decltype(Sorter::operator()(utility::begin(iterable), utility::end(iterable), std::less<>{}, projection))
                 >
             {
-                return Sorter::operator()(detail::begin(iterable), detail::end(iterable), std::less<>{}, projection);
+                return Sorter::operator()(utility::begin(iterable), utility::end(iterable), std::less<>{}, projection);
             }
 
             ////////////////////////////////////////////////////////////
@@ -319,7 +319,7 @@ namespace cppsort
                 -> std::enable_if_t<
                     not detail::has_comparison_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         std::less<>
                     >::value,
                     decltype(operator()(std::forward<Iterable>(iterable)))
@@ -352,12 +352,12 @@ namespace cppsort
                 -> std::enable_if_t<
                     not detail::has_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                     utility::identity
                     >::value &&
                     not detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         std::less<>,
                         utility::identity
                     >::value,
@@ -402,14 +402,14 @@ namespace cppsort
                     not detail::has_comparison_projection_sort<Sorter, Iterable, Compare, Projection>::value &&
                         detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         Compare,
                         Projection
                     >::value,
-                    decltype(Sorter::operator()(detail::begin(iterable), detail::end(iterable), compare, projection))
+                    decltype(Sorter::operator()(utility::begin(iterable), utility::end(iterable), compare, projection))
                 >
             {
-                return Sorter::operator()(detail::begin(iterable), detail::end(iterable), compare, projection);
+                return Sorter::operator()(utility::begin(iterable), utility::end(iterable), compare, projection);
             }
 
             ////////////////////////////////////////////////////////////
@@ -435,7 +435,7 @@ namespace cppsort
                 -> std::enable_if_t<
                     not detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         std::less<>,
                         utility::identity
                     >::value,
@@ -506,14 +506,14 @@ namespace cppsort
                     >::value &&
                     detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         std::less<>,
                         Projection
                     >::value,
-                    decltype(Sorter::operator()(detail::begin(iterable), detail::end(iterable), std::less<>{}, projection))
+                    decltype(Sorter::operator()(utility::begin(iterable), utility::end(iterable), std::less<>{}, projection))
                 >
             {
-                return Sorter::operator()(detail::begin(iterable), detail::end(iterable), std::less<>{}, projection);
+                return Sorter::operator()(utility::begin(iterable), utility::end(iterable), std::less<>{}, projection);
             }
 
             template<typename Iterable, typename Projection>
@@ -527,7 +527,7 @@ namespace cppsort
                     >::value &&
                     not detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         std::less<>,
                         Projection
                     >::value &&
@@ -553,7 +553,7 @@ namespace cppsort
                     >::value &&
                     not detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         std::less<>,
                         Projection
                     >::value &&
@@ -564,13 +564,13 @@ namespace cppsort
                     >::value &&
                     detail::has_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         Projection
                     >::value,
-                    decltype(Sorter::operator()(detail::begin(iterable), detail::end(iterable), projection))
+                    decltype(Sorter::operator()(utility::begin(iterable), utility::end(iterable), projection))
                 >
             {
-                return Sorter::operator()(detail::begin(iterable), detail::end(iterable), projection);
+                return Sorter::operator()(utility::begin(iterable), utility::end(iterable), projection);
             }
 
             ////////////////////////////////////////////////////////////
@@ -623,12 +623,12 @@ namespace cppsort
                 -> std::enable_if_t<
                     not detail::has_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         Projection
                     >::value &&
                     not detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         std::less<>,
                         Projection
                     >::value &&
@@ -648,12 +648,12 @@ namespace cppsort
                 -> std::enable_if_t<
                     not detail::has_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         Projection
                     >::value &&
                     not detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         std::less<>,
                         Projection
                     >::value &&
@@ -664,13 +664,13 @@ namespace cppsort
                     >::value &&
                     detail::has_comparison_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         detail::projection_compare<std::less<>, Projection>
                     >::value,
-                    decltype(Sorter::operator()(detail::begin(iterable), detail::end(iterable), detail::make_projection_compare(std::less<>{}, projection)))
+                    decltype(Sorter::operator()(utility::begin(iterable), utility::end(iterable), detail::make_projection_compare(std::less<>{}, projection)))
                 >
             {
-                return Sorter::operator()(detail::begin(iterable), detail::end(iterable), detail::make_projection_compare(std::less<>{}, projection));
+                return Sorter::operator()(utility::begin(iterable), utility::end(iterable), detail::make_projection_compare(std::less<>{}, projection));
             }
 
             template<typename Iterable, typename Compare, typename Projection>
@@ -678,7 +678,7 @@ namespace cppsort
                 -> std::enable_if_t<
                     not detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         Compare,
                         Projection
                     >::value &&
@@ -698,7 +698,7 @@ namespace cppsort
                 -> std::enable_if_t<
                     not detail::has_comparison_projection_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         Compare,
                         Projection
                     >::value &&
@@ -709,13 +709,13 @@ namespace cppsort
                     >::value &&
                     detail::has_comparison_sort_iterator<
                         Sorter,
-                        decltype(detail::begin(iterable)),
+                        decltype(utility::begin(iterable)),
                         detail::projection_compare<Compare, Projection>
                     >::value,
-                    decltype(Sorter::operator()(detail::begin(iterable), detail::end(iterable), detail::make_projection_compare(compare, projection)))
+                    decltype(Sorter::operator()(utility::begin(iterable), utility::end(iterable), detail::make_projection_compare(compare, projection)))
                 >
             {
-                return Sorter::operator()(detail::begin(iterable), detail::end(iterable), detail::make_projection_compare(compare, projection));
+                return Sorter::operator()(utility::begin(iterable), utility::end(iterable), detail::make_projection_compare(compare, projection));
             }
     };
 }

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -35,6 +35,7 @@
 #include <cpp-sort/utility/functional.h>
 #include <cpp-sort/utility/size.h>
 #include <cpp-sort/utility/static_const.h>
+#include "../detail/begin_end.h"
 #include "../detail/iterator_traits.h"
 #include "../detail/merge_sort.h"
 
@@ -55,19 +56,19 @@ namespace cppsort
                     is_projection_v<Projection, ForwardIterable, Compare>
                 >
             >
-            auto operator()(ForwardIterable& iterable,
+            auto operator()(ForwardIterable&& iterable,
                             Compare compare={}, Projection projection={}) const
                 -> void
             {
                 static_assert(
                     std::is_base_of<
                         std::forward_iterator_tag,
-                        iterator_category_t<decltype(std::begin(iterable))>
+                        iterator_category_t<decltype(detail::begin(iterable))>
                     >::value,
                     "merge_sorter requires at least forward iterators"
                 );
 
-                merge_sort(std::begin(iterable), std::end(iterable),
+                merge_sort(detail::begin(iterable), detail::end(iterable),
                            utility::size(iterable),
                            compare, projection);
             }

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -32,10 +32,10 @@
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/begin_end.h>
 #include <cpp-sort/utility/functional.h>
 #include <cpp-sort/utility/size.h>
 #include <cpp-sort/utility/static_const.h>
-#include "../detail/begin_end.h"
 #include "../detail/iterator_traits.h"
 #include "../detail/merge_sort.h"
 
@@ -63,12 +63,12 @@ namespace cppsort
                 static_assert(
                     std::is_base_of<
                         std::forward_iterator_tag,
-                        iterator_category_t<decltype(detail::begin(iterable))>
+                        iterator_category_t<decltype(utility::begin(iterable))>
                     >::value,
                     "merge_sorter requires at least forward iterators"
                 );
 
-                merge_sort(detail::begin(iterable), detail::end(iterable),
+                merge_sort(utility::begin(iterable), utility::end(iterable),
                            utility::size(iterable),
                            compare, projection);
             }

--- a/include/cpp-sort/sorters/quick_sorter.h
+++ b/include/cpp-sort/sorters/quick_sorter.h
@@ -32,10 +32,10 @@
 #include <type_traits>
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/begin_end.h>
 #include <cpp-sort/utility/functional.h>
 #include <cpp-sort/utility/size.h>
 #include <cpp-sort/utility/static_const.h>
-#include "../detail/begin_end.h"
 #include "../detail/iterator_traits.h"
 #include "../detail/quicksort.h"
 
@@ -63,12 +63,12 @@ namespace cppsort
                 static_assert(
                     std::is_base_of<
                         std::forward_iterator_tag,
-                        iterator_category_t<decltype(detail::begin(iterable))>
+                        iterator_category_t<decltype(utility::begin(iterable))>
                     >::value,
                     "quick_sorter requires at least forward iterators"
                 );
 
-                quicksort(detail::begin(iterable), detail::end(iterable),
+                quicksort(utility::begin(iterable), utility::end(iterable),
                           utility::size(iterable),
                           compare, projection);
             }

--- a/include/cpp-sort/sorters/quick_sorter.h
+++ b/include/cpp-sort/sorters/quick_sorter.h
@@ -35,6 +35,7 @@
 #include <cpp-sort/utility/functional.h>
 #include <cpp-sort/utility/size.h>
 #include <cpp-sort/utility/static_const.h>
+#include "../detail/begin_end.h"
 #include "../detail/iterator_traits.h"
 #include "../detail/quicksort.h"
 
@@ -55,19 +56,19 @@ namespace cppsort
                     is_projection_v<Projection, ForwardIterable, Compare>
                 >
             >
-            auto operator()(ForwardIterable& iterable,
+            auto operator()(ForwardIterable&& iterable,
                             Compare compare={}, Projection projection={}) const
                 -> void
             {
                 static_assert(
                     std::is_base_of<
                         std::forward_iterator_tag,
-                        iterator_category_t<decltype(std::begin(iterable))>
+                        iterator_category_t<decltype(detail::begin(iterable))>
                     >::value,
                     "quick_sorter requires at least forward iterators"
                 );
 
-                quicksort(std::begin(iterable), std::end(iterable),
+                quicksort(detail::begin(iterable), detail::end(iterable),
                           utility::size(iterable),
                           compare, projection);
             }

--- a/include/cpp-sort/stable_sort.h
+++ b/include/cpp-sort/stable_sort.h
@@ -28,6 +28,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <type_traits>
+#include <utility>
 #include <cpp-sort/adapters/stable_adapter.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/sorters/default_sorter.h>
@@ -38,10 +39,10 @@ namespace cppsort
     // With default_sorter
 
     template<typename Iterable>
-    auto stable_sort(Iterable& iterable)
+    auto stable_sort(Iterable&& iterable)
         -> void
     {
-        stable_adapter<default_sorter>{}(iterable);
+        stable_adapter<default_sorter>{}(std::forward<Iterable>(iterable));
     }
 
     template<
@@ -49,10 +50,10 @@ namespace cppsort
         typename Compare,
         typename = std::enable_if_t<not is_sorter_v<Compare, Iterable>>
     >
-    auto stable_sort(Iterable& iterable, Compare compare)
+    auto stable_sort(Iterable&& iterable, Compare compare)
         -> void
     {
-        stable_adapter<default_sorter>{}(iterable, compare);
+        stable_adapter<default_sorter>{}(std::forward<Iterable>(iterable), compare);
     }
 
     template<
@@ -60,14 +61,14 @@ namespace cppsort
         typename Compare,
         typename Projection,
         typename = std::enable_if_t<
-            not is_comparison_sorter_v<Compare, Iterable, Projection> &&
-            not is_projection_sorter_v<Compare, Iterable, Projection>
+            not is_comparison_sorter_v<Iterable, Compare, Projection> &&
+            not is_projection_sorter_v<Iterable, Compare, Projection>
         >
     >
-    auto stable_sort(Iterable& iterable, Compare compare, Projection projection)
+    auto stable_sort(Iterable&& iterable, Compare compare, Projection projection)
         -> void
     {
-        stable_adapter<default_sorter>{}(iterable, compare, projection);
+        stable_adapter<default_sorter>{}(std::forward<Iterable>(iterable), compare, projection);
     }
 
     template<typename Iterator>
@@ -113,10 +114,10 @@ namespace cppsort
             stable_adapter<Sorter>, Iterable
         >>
     >
-    auto stable_sort(const Sorter&, Iterable& iterable)
+    auto stable_sort(const Sorter&, Iterable&& iterable)
         -> decltype(auto)
     {
-        return stable_adapter<Sorter>{}(iterable);
+        return stable_adapter<Sorter>{}(std::forward<Iterable>(iterable));
     }
 
     template<
@@ -128,10 +129,10 @@ namespace cppsort
             is_projection_sorter_v<stable_adapter<Sorter>, Iterable, Func>
         >
     >
-    auto stable_sort(const Sorter&, Iterable& iterable, Func func)
+    auto stable_sort(const Sorter&, Iterable&& iterable, Func func)
         -> decltype(auto)
     {
-        return stable_adapter<Sorter>{}(iterable, func);
+        return stable_adapter<Sorter>{}(std::forward<Iterable>(iterable), func);
     }
 
     template<
@@ -140,11 +141,11 @@ namespace cppsort
         typename Compare,
         typename Projection
     >
-    auto stable_sort(const Sorter&, Iterable& iterable,
+    auto stable_sort(const Sorter&, Iterable&& iterable,
                      Compare compare, Projection projection)
         -> decltype(auto)
     {
-        return stable_adapter<Sorter>{}(iterable, compare, projection);
+        return stable_adapter<Sorter>{}(std::forward<Iterable>(iterable), compare, projection);
     }
 
     template<

--- a/include/cpp-sort/utility/begin_end.h
+++ b/include/cpp-sort/utility/begin_end.h
@@ -1,4 +1,4 @@
-/// \file
+//
 // Range v3 library
 //
 //  Copyright Eric Niebler 2013-2014
@@ -12,8 +12,8 @@
 // Project home: https://github.com/ericniebler/range-v3
 //
 
-#ifndef CPPSORT_DETAIL_BEGIN_END_H_
-#define CPPSORT_DETAIL_BEGIN_END_H_
+#ifndef CPPSORT_UTILITY_BEGIN_END_H_
+#define CPPSORT_UTILITY_BEGIN_END_H_
 
 ////////////////////////////////////////////////////////////
 // Headers
@@ -27,7 +27,7 @@
 
 namespace cppsort
 {
-namespace detail
+namespace utility
 {
     namespace adl_begin_end_detail
     {
@@ -344,4 +344,4 @@ namespace detail
     }
 }}
 
-#endif // CPPSORT_DETAIL_BEGIN_END_H_
+#endif // CPPSORT_UTILITY_BEGIN_END_H_

--- a/include/cpp-sort/utility/size.h
+++ b/include/cpp-sort/utility/size.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2016 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,9 @@
 #include <cstddef>
 #include <iterator>
 #include <type_traits>
+#include <utility>
 #include <cpp-sort/utility/detection.h>
+#include "../detail/begin_end.h"
 
 namespace cppsort
 {
@@ -57,9 +59,11 @@ namespace utility
         typename = std::enable_if_t<not is_detected_v<detail::has_size_method_t, Iterable>>
     >
     constexpr auto size(const Iterable& iterable)
-        -> decltype(std::distance(std::begin(iterable), std::end(iterable)))
+        -> decltype(std::distance(cppsort::detail::begin(iterable),
+                                  cppsort::detail::end(iterable)))
     {
-        return std::distance(std::begin(iterable), std::end(iterable));
+        return std::distance(cppsort::detail::begin(iterable),
+                             cppsort::detail::end(iterable));
     }
 
     template<typename T, std::size_t N>

--- a/include/cpp-sort/utility/size.h
+++ b/include/cpp-sort/utility/size.h
@@ -31,8 +31,8 @@
 #include <iterator>
 #include <type_traits>
 #include <utility>
+#include <cpp-sort/utility/begin_end.h>
 #include <cpp-sort/utility/detection.h>
-#include "../detail/begin_end.h"
 
 namespace cppsort
 {
@@ -59,11 +59,11 @@ namespace utility
         typename = std::enable_if_t<not is_detected_v<detail::has_size_method_t, Iterable>>
     >
     constexpr auto size(const Iterable& iterable)
-        -> decltype(std::distance(cppsort::detail::begin(iterable),
-                                  cppsort::detail::end(iterable)))
+        -> decltype(std::distance(utility::begin(iterable),
+                                  utility::end(iterable)))
     {
-        return std::distance(cppsort::detail::begin(iterable),
-                             cppsort::detail::end(iterable));
+        return std::distance(utility::begin(iterable),
+                             utility::end(iterable));
     }
 
     template<typename T, std::size_t N>

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(
     every_instantiated_sorter.cpp
     every_sorter.cpp
     every_sorter_move_only.cpp
+    every_sorter_span.cpp
     rebind_iterator_category.cpp
     sorter_facade.cpp
     sorter_facade_defaults.cpp

--- a/testsuite/adapters/counting_adapter.cpp
+++ b/testsuite/adapters/counting_adapter.cpp
@@ -34,6 +34,7 @@
 #include <cpp-sort/sorters/selection_sorter.h>
 #include <cpp-sort/sorters/std_sorter.h>
 #include "../algorithm.h"
+#include "../span.h"
 
 TEST_CASE( "basic counting_adapter tests",
            "[counting_adapter][selection_sorter]" )
@@ -100,5 +101,47 @@ TEST_CASE( "counting_adapter tests with std_sorter",
         // Sort and check it's sorted
         cppsort::sort(sorter{}, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}
+
+TEST_CASE( "counting_adapter with span",
+           "[counting_adapter][span][selection_sorter]" )
+{
+    // Pseudo-random number engine
+    std::mt19937_64 engine(std::time(nullptr));
+
+    using sorter = cppsort::counting_adapter<
+        cppsort::selection_sorter
+    >;
+
+    SECTION( "without projections" )
+    {
+        // Fill the collection
+        std::vector<int> tmp(65);
+        std::iota(std::begin(tmp), std::end(tmp), 0);
+        std::shuffle(std::begin(tmp), std::end(tmp), engine);
+        std::list<int> collection(std::begin(tmp), std::end(tmp));
+
+        // Sort and check it's sorted
+        std::size_t res = cppsort::sort(sorter{}, make_span(collection));
+        CHECK( res == 2080 );
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "with projections" )
+    {
+        struct wrapper { int value; };
+
+        // Fill the collection
+        std::vector<wrapper> tmp(80);
+        helpers::iota(std::begin(tmp), std::end(tmp), 0, &wrapper::value);
+        std::shuffle(std::begin(tmp), std::end(tmp), engine);
+        std::list<wrapper> collection(std::begin(tmp), std::end(tmp));
+
+        // Sort and check it's sorted
+        std::size_t res = cppsort::sort(sorter{}, make_span(collection), &wrapper::value);
+        CHECK( res == 3160 );
+        CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
+                                  std::less<>{}, &wrapper::value) );
     }
 }

--- a/testsuite/adapters/indirect_adapter.cpp
+++ b/testsuite/adapters/indirect_adapter.cpp
@@ -33,6 +33,7 @@
 #include <cpp-sort/sort.h>
 #include <cpp-sort/sorters/quick_sorter.h>
 #include "../algorithm.h"
+#include "../span.h"
 
 TEST_CASE( "basic tests with indirect_adapter",
            "[indirect_adapter]" )
@@ -76,6 +77,38 @@ TEST_CASE( "basic tests with indirect_adapter",
         std::shuffle(std::begin(collection), std::end(collection), engine);
         cppsort::sort(sorter{}, std::begin(collection), std::end(collection),
                       std::greater<>{}, std::negate<>{});
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}
+
+TEST_CASE( "indirect_adapter with temporary span",
+           "[indirect_adapter][span]" )
+{
+    std::vector<int> collection(221);
+    std::iota(std::begin(collection), std::end(collection), -32);
+    std::mt19937 engine(std::time(nullptr));
+    std::shuffle(std::begin(collection), std::end(collection), engine);
+
+    using sorter = cppsort::indirect_adapter<
+        cppsort::quick_sorter
+    >;
+
+    SECTION( "with comparison" )
+    {
+        cppsort::sort(sorter{}, make_span(collection), std::greater<>{});
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection), std::greater<>{}) );
+    }
+
+    SECTION( "with projection" )
+    {
+        cppsort::sort(sorter{}, make_span(collection), std::negate<>{});
+        CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
+                                  std::less<>{}, std::negate<>{}) );
+    }
+
+    SECTION( "with comparison and projection" )
+    {
+        cppsort::sort(sorter{}, make_span(collection), std::greater<>{}, std::negate<>{});
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 }

--- a/testsuite/every_sorter_span.cpp
+++ b/testsuite/every_sorter_span.cpp
@@ -1,0 +1,178 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <ctime>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+
+template<typename Iterator>
+class span
+{
+    public:
+
+        template<typename Iterable>
+        span(Iterable& iterable):
+            _begin(std::begin(iterable)),
+            _end(std::end(iterable))
+        {}
+
+        auto begin() const { return _begin; }
+        auto end() const { return _end; }
+
+    private:
+
+        Iterator _begin, _end;
+};
+
+template<typename Iterable>
+auto make_span(Iterable& iterable)
+    -> span<decltype(std::begin(iterable))>
+{
+    return { iterable };
+}
+
+TEST_CASE( "test every sorter with temporary span",
+           "[sorters][span]" )
+{
+    // General test to make sure that every sorter compiles fine
+    // and is able to sort a vector of numbers. spread_sorter is
+    // already tested in-depth somewhere else and needs specific
+    // tests, so it's not included here.
+
+    std::vector<double> collection(491);
+    std::iota(std::begin(collection), std::end(collection), -125);
+    std::mt19937 engine(std::time(nullptr));
+    std::shuffle(std::begin(collection), std::end(collection), engine);
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        sort(block_sorter<>{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "default_sorter" )
+    {
+        cppsort::sort(cppsort::default_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        sort(grail_sorter<>{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "insertion_sorter" )
+    {
+        cppsort::sort(cppsort::insertion_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_insertion_sorter" )
+    {
+        cppsort::sort(cppsort::merge_insertion_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "selection_sorter" )
+    {
+        cppsort::sort(cppsort::selection_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/every_sorter_span.cpp
+++ b/testsuite/every_sorter_span.cpp
@@ -32,32 +32,7 @@
 #include <cpp-sort/sorters.h>
 #include <cpp-sort/utility/buffer.h>
 #include <cpp-sort/utility/functional.h>
-
-template<typename Iterator>
-class span
-{
-    public:
-
-        template<typename Iterable>
-        span(Iterable& iterable):
-            _begin(std::begin(iterable)),
-            _end(std::end(iterable))
-        {}
-
-        auto begin() const { return _begin; }
-        auto end() const { return _end; }
-
-    private:
-
-        Iterator _begin, _end;
-};
-
-template<typename Iterable>
-auto make_span(Iterable& iterable)
-    -> span<decltype(std::begin(iterable))>
-{
-    return { iterable };
-}
+#include "span.h"
 
 TEST_CASE( "test every sorter with temporary span",
            "[sorters][span]" )

--- a/testsuite/span.h
+++ b/testsuite/span.h
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <iterator>
+
+////////////////////////////////////////////////////////////
+// Very basic span type
+//
+// While the original goal of sorters is to sort some kinds
+// of collections that are typically lvalues, there are more
+// and more span-like types (GSL, Ranges v3...) and these
+// might be passed to sorters as temporary values.
+//
+// Therefore sorters need to handle temporary span-like
+// classes like the one below too.
+//
+
+template<typename Iterator>
+class span
+{
+    public:
+
+        template<typename Iterable>
+        span(Iterable& iterable):
+            _begin(std::begin(iterable)),
+            _end(std::end(iterable))
+        {}
+
+        auto begin() const { return _begin; }
+        auto end() const { return _end; }
+
+    private:
+
+        Iterator _begin, _end;
+};
+
+template<typename Iterable>
+auto make_span(Iterable& iterable)
+    -> span<decltype(std::begin(iterable))>
+{
+    return { iterable };
+}


### PR DESCRIPTION
This commit enhances sorters so that they can also sort temporary ranges. While this is useless at best and error-prone at worst for standard containers, it is required to handle temporary span-like classes such as `gsl::span` that are more and more common in the C++ realm, and that could even be standardized in a few years.

This also introduces `utility::begin` and `utility::end` (directly taken from Eric Niebler's Range v3) to bypass the fact that `std::begin` and `std::end` can't return mutable iterators when given rvalues.