### PR TITLE
Revamp is_stable. Fixes #75.

### DIFF
--- a/examples/bubble_sorter.cpp
+++ b/examples/bubble_sorter.cpp
@@ -113,7 +113,7 @@ namespace detail
 
         // Sorter traits
         using iterator_category = std::forward_iterator_tag;
-        using is_stable = std::true_type;
+        using is_always_stable = std::true_type;
     };
 }
 

--- a/include/cpp-sort/adapters/container_aware_adapter.h
+++ b/include/cpp-sort/adapters/container_aware_adapter.h
@@ -106,69 +106,119 @@ namespace cppsort
         template<typename Sorter>
         struct container_aware_adapter_base
         {
-            template<typename Iterable>
+            template<
+                bool Stability = false,
+                typename Iterable
+            >
             auto operator()(Iterable& iterable) const
                 -> std::enable_if_t<
                     detail::can_sort<Sorter, Iterable>::value,
-                    decltype(detail::adl_despair{}(Sorter{}, iterable))
+                    std::conditional_t<
+                        Stability,
+                        std::false_type,
+                        decltype(detail::adl_despair{}(Sorter{}, iterable))
+                    >
                 >
             {
                 return detail::adl_despair{}(Sorter{}, iterable);
             }
 
-            template<typename Iterable>
+            template<
+                bool Stability = false,
+                typename Iterable
+            >
             auto operator()(Iterable& iterable) const
                 -> std::enable_if_t<
                     not detail::can_sort<Sorter, Iterable>::value,
-                    decltype(cppsort::sort(Sorter{}, iterable))
+                    std::conditional_t<
+                        Stability,
+                        cppsort::is_stable<Sorter(Iterable&)>,
+                        decltype(cppsort::sort(Sorter{}, iterable))
+                    >
                 >
             {
                 return cppsort::sort(Sorter{}, iterable);
             }
 
-            template<typename Iterable, typename Compare>
+            template<
+                bool Stability = false,
+                typename Iterable,
+                typename Compare
+            >
             auto operator()(Iterable& iterable, Compare compare) const
                 -> std::enable_if_t<
                     detail::can_comparison_sort<Sorter, Iterable, Compare>::value,
-                    decltype(detail::adl_despair{}(Sorter{}, iterable, compare))
+                    std::conditional_t<
+                        Stability,
+                        std::false_type,
+                        decltype(detail::adl_despair{}(Sorter{}, iterable, compare))
+                    >
                 >
             {
                 return detail::adl_despair{}(Sorter{}, iterable, compare);
             }
 
-            template<typename Iterable, typename Compare>
+            template<
+                bool Stability = false,
+                typename Iterable,
+                typename Compare
+            >
             auto operator()(Iterable& iterable, Compare compare) const
                 -> std::enable_if_t<
                     not is_projection<Compare, Iterable>::value &&
                     not detail::can_comparison_sort<Sorter, Iterable, Compare>::value,
-                    decltype(cppsort::sort(Sorter{}, iterable, compare))
+                    std::conditional_t<
+                        Stability,
+                        cppsort::is_stable<Sorter(Iterable&, Compare)>,
+                        decltype(cppsort::sort(Sorter{}, iterable, compare))
+                    >
                 >
             {
                 return cppsort::sort(Sorter{}, iterable, compare);
             }
 
-            template<typename Iterable, typename Projection>
+            template<
+                bool Stability = false,
+                typename Iterable,
+                typename Projection
+            >
             auto operator()(Iterable& iterable, Projection projection) const
                 -> std::enable_if_t<
                     detail::can_projection_sort<Sorter, Iterable, Projection>::value,
-                    decltype(detail::adl_despair{}(Sorter{}, iterable, projection))
+                    std::conditional_t<
+                        Stability,
+                        std::false_type,
+                        decltype(detail::adl_despair{}(Sorter{}, iterable, projection))
+                    >
                 >
             {
                 return detail::adl_despair{}(Sorter{}, iterable, projection);
             }
 
-            template<typename Iterable, typename Projection>
+            template<
+                bool Stability = false,
+                typename Iterable,
+                typename Projection
+            >
             auto operator()(Iterable& iterable, Projection projection) const
                 -> std::enable_if_t<
                     not detail::can_projection_sort<Sorter, Iterable, Projection>::value &&
-                        detail::can_comparison_projection_sort<Sorter, Iterable, std::less<>, Projection>::value,
-                    decltype(detail::adl_despair{}(Sorter{}, iterable, std::less<>{}, projection))
+                    detail::can_comparison_projection_sort<Sorter, Iterable, std::less<>, Projection>::value,
+                    std::conditional_t<
+                        Stability,
+                        std::false_type,
+                        decltype(detail::adl_despair{}(Sorter{}, iterable, std::less<>{}, projection))
+                    >
                 >
             {
                 return detail::adl_despair{}(Sorter{}, iterable, std::less<>{}, projection);
             }
 
-            template<typename Iterable, typename Projection>
+            template<
+                bool Stability = false,
+                typename Iterable,
+                typename Projection
+            >
             auto operator()(Iterable& iterable, Projection projection) const
                 -> std::enable_if_t<
                     not detail::can_projection_sort<Sorter, Iterable, Projection>::value &&
@@ -178,13 +228,21 @@ namespace cppsort
                         Iterable,
                         detail::projection_compare<std::less<>, Projection>
                     >::value,
-                    decltype(detail::adl_despair{}(Sorter{}, iterable, detail::make_projection_compare(std::less<>{}, projection)))
+                    std::conditional_t<
+                        Stability,
+                        std::false_type,
+                        decltype(detail::adl_despair{}(Sorter{}, iterable, detail::make_projection_compare(std::less<>{}, projection)))
+                    >
                 >
             {
                 return detail::adl_despair{}(Sorter{}, iterable, detail::make_projection_compare(std::less<>{}, projection));
             }
 
-            template<typename Iterable, typename Projection>
+            template<
+                bool Stability = false,
+                typename Iterable,
+                typename Projection
+            >
             auto operator()(Iterable& iterable, Projection projection) const
                 -> std::enable_if_t<
                     is_projection<Projection, Iterable>::value &&
@@ -195,23 +253,41 @@ namespace cppsort
                         Iterable,
                         detail::projection_compare<std::less<>, Projection>
                     >::value,
-                    decltype(cppsort::sort(Sorter{}, iterable, projection))
+                    std::conditional_t<
+                        Stability,
+                        cppsort::is_stable<Sorter(Iterable&, Projection)>,
+                        decltype(cppsort::sort(Sorter{}, iterable, projection))
+                    >
                 >
             {
                 return cppsort::sort(Sorter{}, iterable, projection);
             }
 
-            template<typename Iterable, typename Compare, typename Projection>
+            template<
+                bool Stability = false,
+                typename Iterable,
+                typename Compare,
+                typename Projection
+            >
             auto operator()(Iterable& iterable, Compare compare, Projection projection) const
                 -> std::enable_if_t<
                     detail::can_comparison_projection_sort<Sorter, Iterable, Compare, Projection>::value,
-                    decltype(detail::adl_despair{}(Sorter{}, iterable, compare, projection))
+                    std::conditional_t<
+                        Stability,
+                        std::false_type,
+                        decltype(detail::adl_despair{}(Sorter{}, iterable, compare, projection))
+                    >
                 >
             {
                 return detail::adl_despair{}(Sorter{}, iterable, compare, projection);
             }
 
-            template<typename Iterable, typename Compare, typename Projection>
+            template<
+                bool Stability = false,
+                typename Iterable,
+                typename Compare,
+                typename Projection
+            >
             auto operator()(Iterable& iterable, Compare compare, Projection projection) const
                 -> std::enable_if_t<
                     not detail::can_comparison_projection_sort<Sorter, Iterable, Compare, Projection>::value &&
@@ -220,13 +296,22 @@ namespace cppsort
                         Iterable,
                         detail::projection_compare<Compare, Projection>
                     >::value,
-                    decltype(detail::adl_despair{}(Sorter{}, iterable, detail::make_projection_compare(compare, projection)))
+                    std::conditional_t<
+                        Stability,
+                        std::false_type,
+                        decltype(detail::adl_despair{}(Sorter{}, iterable, detail::make_projection_compare(compare, projection)))
+                    >
                 >
             {
                 return detail::adl_despair{}(Sorter{}, iterable, detail::make_projection_compare(compare, projection));
             }
 
-            template<typename Iterable, typename Compare, typename Projection>
+            template<
+                bool Stability = false,
+                typename Iterable,
+                typename Compare,
+                typename Projection
+            >
             auto operator()(Iterable& iterable, Compare compare, Projection projection) const
                 -> std::enable_if_t<
                     not detail::can_comparison_projection_sort<Sorter, Iterable, Compare, Projection>::value &&
@@ -235,7 +320,11 @@ namespace cppsort
                         Iterable,
                         detail::projection_compare<Compare, Projection>
                     >::value,
-                    decltype(cppsort::sort(Sorter{}, iterable, compare, projection))
+                    std::conditional_t<
+                        Stability,
+                        cppsort::is_stable<Sorter(Iterable&, Compare, Projection)>,
+                        decltype(cppsort::sort(Sorter{}, iterable, compare, projection))
+                    >
                 >
             {
                 return cppsort::sort(Sorter{}, iterable, compare, projection);
@@ -246,6 +335,14 @@ namespace cppsort
     template<typename Sorter>
     struct container_aware_adapter:
         detail::container_aware_adapter_base<Sorter>
+    {};
+
+    ////////////////////////////////////////////////////////////
+    // is_stable specialization
+
+    template<typename Sorter, typename... Args>
+    struct is_stable<container_aware_adapter<Sorter>(Args...)>:
+        decltype(container_aware_adapter<Sorter>{}.template operator()<true>(std::declval<Args&>()...))
     {};
 }
 

--- a/include/cpp-sort/adapters/counting_adapter.h
+++ b/include/cpp-sort/adapters/counting_adapter.h
@@ -124,6 +124,14 @@ namespace cppsort
             CountType
         >>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // is_stable specialization
+
+    template<typename Sorter, typename CountType, typename... Args>
+    struct is_stable<counting_adapter<Sorter, CountType>(Args...)>:
+        is_stable<Sorter(Args...)>
+    {};
 }
 
 #endif // CPPSORT_ADAPTERS_COUNTING_ADAPTER_H_

--- a/include/cpp-sort/adapters/counting_adapter.h
+++ b/include/cpp-sort/adapters/counting_adapter.h
@@ -46,7 +46,7 @@ namespace cppsort
         template<typename ComparisonSorter, typename CountType>
         struct counting_adapter_impl:
             check_iterator_category<ComparisonSorter>,
-            check_is_stable<ComparisonSorter>
+            check_is_always_stable<ComparisonSorter>
         {
             template<
                 typename Iterable,

--- a/include/cpp-sort/adapters/hybrid_adapter.h
+++ b/include/cpp-sort/adapters/hybrid_adapter.h
@@ -79,7 +79,7 @@ namespace cppsort
         template<typename... Sorters>
         class hybrid_adapter_impl:
             public check_iterator_category<Sorters...>,
-            public check_is_stable<Sorters...>
+            public check_is_always_stable<Sorters...>
         {
             private:
 

--- a/include/cpp-sort/adapters/indirect_adapter.h
+++ b/include/cpp-sort/adapters/indirect_adapter.h
@@ -132,6 +132,14 @@ namespace cppsort
     struct indirect_adapter:
         sorter_facade<detail::indirect_adapter_impl<Sorter>>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // is_stable specialization
+
+    template<typename Sorter, typename... Args>
+    struct is_stable<indirect_adapter<Sorter>(Args...)>:
+        is_stable<Sorter(Args...)>
+    {};
 }
 
 #endif // CPPSORT_ADAPTERS_INDIRECT_ADAPTER_H_

--- a/include/cpp-sort/adapters/indirect_adapter.h
+++ b/include/cpp-sort/adapters/indirect_adapter.h
@@ -48,7 +48,7 @@ namespace cppsort
     {
         template<typename Sorter>
         struct indirect_adapter_impl:
-            check_is_stable<Sorter>
+            check_is_always_stable<Sorter>
         {
             template<
                 typename RandomAccessIterator,

--- a/include/cpp-sort/adapters/schwartz_adapter.h
+++ b/include/cpp-sort/adapters/schwartz_adapter.h
@@ -50,7 +50,7 @@ namespace cppsort
         template<typename Sorter>
         struct schwartz_adapter_impl:
             check_iterator_category<Sorter>,
-            check_is_stable<Sorter>
+            check_is_always_stable<Sorter>
         {
             template<typename ForwardIterator, typename Compare, typename Projection>
             auto operator()(ForwardIterator first, ForwardIterator last,

--- a/include/cpp-sort/adapters/schwartz_adapter.h
+++ b/include/cpp-sort/adapters/schwartz_adapter.h
@@ -109,6 +109,14 @@ namespace cppsort
     struct schwartz_adapter:
         sorter_facade<detail::schwartz_adapter_impl<Sorter>>
     {};
+
+    ////////////////////////////////////////////////////////////
+    // is_stable specialization
+
+    template<typename Sorter, typename... Args>
+    struct is_stable<schwartz_adapter<Sorter>(Args...)>:
+        is_stable<Sorter(Args...)>
+    {};
 }
 
 #ifdef CPPSORT_ADAPTERS_SMALL_ARRAY_ADAPTER_H_

--- a/include/cpp-sort/adapters/self_sort_adapter.h
+++ b/include/cpp-sort/adapters/self_sort_adapter.h
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <forward_list>
+#include <list>
 #include <type_traits>
 #include <utility>
 #include <cpp-sort/sorter_facade.h>
@@ -144,6 +146,34 @@ namespace cppsort
                 std::true_type,
                 is_stable<Sorter(Args...)>
             >
+        >
+    {};
+
+    template<typename Sorter, typename T>
+    struct is_stable<self_sort_adapter<Sorter>(std::forward_list<T>&)>:
+        std::true_type
+    {};
+
+    template<typename Sorter, typename T, typename Function>
+    struct is_stable<self_sort_adapter<Sorter>(std::forward_list<T>&, Function)>:
+        std::conditional_t<
+            is_projection_v<Function, std::forward_list<T>&>,
+            is_stable<Sorter(std::forward_list<T>&, Function)>,
+            std::true_type
+        >
+    {};
+
+    template<typename Sorter, typename T>
+    struct is_stable<self_sort_adapter<Sorter>(std::list<T>&)>:
+        std::true_type
+    {};
+
+    template<typename Sorter, typename T, typename Function>
+    struct is_stable<self_sort_adapter<Sorter>(std::list<T>&, Function)>:
+        std::conditional_t<
+            is_projection_v<Function, std::list<T>&>,
+            is_stable<Sorter(std::list<T>&, Function)>,
+            std::true_type
         >
     {};
 }

--- a/include/cpp-sort/adapters/self_sort_adapter.h
+++ b/include/cpp-sort/adapters/self_sort_adapter.h
@@ -117,8 +117,6 @@ namespace cppsort
             ////////////////////////////////////////////////////////////
             // Sorter traits
 
-            // We can't guarantee the stability of the sort method,
-            // therefore we default the stability to false
             using is_always_stable = std::false_type;
         };
     }
@@ -126,6 +124,27 @@ namespace cppsort
     template<typename Sorter>
     struct self_sort_adapter:
         sorter_facade<detail::self_sort_adapter_impl<Sorter>>
+    {};
+
+    ////////////////////////////////////////////////////////////
+    // is_stable specializations
+
+    template<typename Sorter, typename Iterator, typename... Args>
+    struct is_stable<self_sort_adapter<Sorter>(Iterator, Iterator, Args...)>:
+        is_stable<Sorter(Iterator, Iterator, Args...)>
+    {};
+
+    template<typename Sorter, typename... Args>
+    struct is_stable<self_sort_adapter<Sorter>(Args...)>:
+        std::conditional_t<
+            detail::has_sort_method<Args...>,
+            std::false_type,
+            std::conditional_t<
+                detail::has_stable_sort_method<Args...>,
+                std::true_type,
+                is_stable<Sorter(Args...)>
+            >
+        >
     {};
 }
 

--- a/include/cpp-sort/adapters/self_sort_adapter.h
+++ b/include/cpp-sort/adapters/self_sort_adapter.h
@@ -119,7 +119,7 @@ namespace cppsort
 
             // We can't guarantee the stability of the sort method,
             // therefore we default the stability to false
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/adapters/small_array_adapter.h
+++ b/include/cpp-sort/adapters/small_array_adapter.h
@@ -135,6 +135,29 @@ namespace cppsort
             return FixedSizeSorter<N>{}(array, std::forward<Args>(args)...);
         }
     };
+
+    ////////////////////////////////////////////////////////////
+    // is_stable specialization
+
+    template<
+        template<std::size_t> class FixedSizeSorter,
+        typename Indices,
+        typename T, std::size_t N,
+        typename... Args
+    >
+    struct is_stable<small_array_adapter<FixedSizeSorter, Indices>(std::array<T, N>&, Args...)>:
+        is_stable<FixedSizeSorter<N>(std::array<T, N>&, Args...)>
+    {};
+
+    template<
+        template<std::size_t> class FixedSizeSorter,
+        typename Indices,
+        typename T, std::size_t N,
+        typename... Args
+    >
+    struct is_stable<small_array_adapter<FixedSizeSorter, Indices>(T (&)[N], Args...)>:
+        is_stable<FixedSizeSorter<N>(T (&)[N], Args...)>
+    {};
 }
 
 #ifdef CPPSORT_ADAPTERS_SCHWARTZ_ADAPTER_H_

--- a/include/cpp-sort/adapters/stable_adapter.h
+++ b/include/cpp-sort/adapters/stable_adapter.h
@@ -154,7 +154,7 @@ namespace cppsort
             ////////////////////////////////////////////////////////////
             // Sorter traits
 
-            using is_stable = std::true_type;
+            using is_always_stable = std::true_type;
         };
     }
 
@@ -168,7 +168,7 @@ namespace cppsort
     template<typename Sorter>
     struct stable_adapter:
         std::conditional_t<
-            is_stable<Sorter>::value,
+            is_always_stable<Sorter>::value,
             Sorter,
             make_stable<Sorter>
         >

--- a/include/cpp-sort/detail/checkers.h
+++ b/include/cpp-sort/detail/checkers.h
@@ -60,21 +60,21 @@ namespace detail
     {};
 
     template<bool, typename...>
-    struct check_is_stable_impl {};
+    struct check_is_always_stable_impl {};
 
     template<typename... Sorters>
-    struct check_is_stable_impl<true, Sorters...>
+    struct check_is_always_stable_impl<true, Sorters...>
     {
-        using is_stable = std::integral_constant<
+        using is_always_stable = std::integral_constant<
             bool,
-            utility::all(typename sorter_traits<Sorters>::is_stable{}()...)
+            utility::all(typename sorter_traits<Sorters>::is_always_stable{}()...)
         >;
     };
 
     template<typename... Sorters>
-    struct check_is_stable:
-        check_is_stable_impl<
-            utility::all(has_is_stable<sorter_traits<Sorters>>::value...),
+    struct check_is_always_stable:
+        check_is_always_stable_impl<
+            utility::all(has_is_always_stable<sorter_traits<Sorters>>::value...),
             Sorters...
         >
     {};

--- a/include/cpp-sort/detail/raw_checkers.h
+++ b/include/cpp-sort/detail/raw_checkers.h
@@ -68,31 +68,31 @@ namespace detail
     {};
 
     template<typename T, typename=void>
-    struct has_is_stable:
+    struct has_is_always_stable:
         std::false_type
     {};
 
     template<typename T>
-    struct has_is_stable<T, utility::void_t<typename T::is_stable>>:
+    struct has_is_always_stable<T, utility::void_t<typename T::is_always_stable>>:
         std::true_type
     {};
 
     template<bool, typename...>
-    struct raw_check_is_stable_impl {};
+    struct raw_check_is_always_stable_impl {};
 
     template<typename... Sorters>
-    struct raw_check_is_stable_impl<true, Sorters...>
+    struct raw_check_is_always_stable_impl<true, Sorters...>
     {
-        using is_stable = std::integral_constant<
+        using is_always_stable = std::integral_constant<
             bool,
-            utility::all(typename Sorters::is_stable{}()...)
+            utility::all(typename Sorters::is_always_stable{}()...)
         >;
     };
 
     template<typename... Sorters>
-    struct raw_check_is_stable:
-        raw_check_is_stable_impl<
-            utility::all(has_is_stable<Sorters>::value...),
+    struct raw_check_is_always_stable:
+        raw_check_is_always_stable_impl<
+            utility::all(has_is_always_stable<Sorters>::value...),
             Sorters...
         >
     {};

--- a/include/cpp-sort/detail/schwartz_small_array.h
+++ b/include/cpp-sort/detail/schwartz_small_array.h
@@ -48,7 +48,8 @@ namespace cppsort
     >
     struct schwartz_adapter<
         small_array_adapter<FixedSizeSorter, std::index_sequence<Indices...>>
-    >
+    >:
+        fixed_sorter_traits<FixedSizeSorter>
     {
         template<
             typename T,
@@ -83,7 +84,8 @@ namespace cppsort
     };
 
     template<template<std::size_t> class FixedSizeSorter>
-    struct schwartz_adapter<small_array_adapter<FixedSizeSorter, void>>
+    struct schwartz_adapter<small_array_adapter<FixedSizeSorter, void>>:
+        fixed_sorter_traits<FixedSizeSorter>
     {
         template<
             typename T,

--- a/include/cpp-sort/detail/stable_adapter_self_sort_adapter.h
+++ b/include/cpp-sort/detail/stable_adapter_self_sort_adapter.h
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <forward_list>
+#include <list>
 #include <type_traits>
 #include <utility>
 
@@ -36,37 +38,80 @@ namespace cppsort
     struct stable_adapter<self_sort_adapter<Sorter>>:
         detail::check_iterator_category<Sorter>
     {
-            template<typename Iterable, typename... Args>
-            auto operator()(Iterable&& iterable, Args&&... args) const
-                -> std::enable_if_t<
-                    detail::has_stable_sort_method<Iterable, Args...>,
-                    decltype(std::forward<Iterable>(iterable).stable_sort(std::forward<Args>(args)...))
-                >
-            {
-                return std::forward<Iterable>(iterable).stable_sort(std::forward<Args>(args)...);
-            }
+        ////////////////////////////////////////////////////////////
+        // Generic cases
 
-            template<typename Iterable, typename... Args>
-            auto operator()(Iterable&& iterable, Args&&... args) const
-                -> std::enable_if_t<
-                    not detail::has_stable_sort_method<Iterable, Args...>,
-                    decltype(stable_adapter<Sorter>{}(std::forward<Iterable>(iterable), std::forward<Args>(args)...))
-                >
-            {
-                return stable_adapter<Sorter>{}(std::forward<Iterable>(iterable), std::forward<Args>(args)...);
-            }
+        template<typename Iterable, typename... Args>
+        auto operator()(Iterable&& iterable, Args&&... args) const
+            -> std::enable_if_t<
+                detail::has_stable_sort_method<Iterable, Args...>,
+                decltype(std::forward<Iterable>(iterable).stable_sort(std::forward<Args>(args)...))
+            >
+        {
+            return std::forward<Iterable>(iterable).stable_sort(std::forward<Args>(args)...);
+        }
 
-            template<typename Iterator, typename... Args>
-            auto operator()(Iterator first, Iterator last, Args&&... args) const
-                -> decltype(stable_adapter<Sorter>{}(first, last, std::forward<Args>(args)...))
-            {
-                return stable_adapter<Sorter>{}(first, last, std::forward<Args>(args)...);
-            }
+        template<typename Iterable, typename... Args>
+        auto operator()(Iterable&& iterable, Args&&... args) const
+            -> std::enable_if_t<
+                not detail::has_stable_sort_method<Iterable, Args...>,
+                decltype(stable_adapter<Sorter>{}(std::forward<Iterable>(iterable), std::forward<Args>(args)...))
+            >
+        {
+            return stable_adapter<Sorter>{}(std::forward<Iterable>(iterable), std::forward<Args>(args)...);
+        }
 
-            ////////////////////////////////////////////////////////////
-            // Sorter traits
+        template<typename Iterator, typename... Args>
+        auto operator()(Iterator first, Iterator last, Args&&... args) const
+            -> decltype(stable_adapter<Sorter>{}(first, last, std::forward<Args>(args)...))
+        {
+            return stable_adapter<Sorter>{}(first, last, std::forward<Args>(args)...);
+        }
 
-            using is_always_stable = std::true_type;
+        ////////////////////////////////////////////////////////////
+        // Special cases for standard library lists whose sort
+        // method implements a stable sort
+
+        template<typename T>
+        auto operator()(std::forward_list<T>& iterable) const
+            -> void
+        {
+            return iterable.sort();
+        }
+
+        template<
+            typename T,
+            typename Compare,
+            typename = std::enable_if_t<not is_projection_v<Compare, std::forward_list<T>&>>
+        >
+        auto operator()(std::forward_list<T>& iterable, Compare compare) const
+            -> void
+        {
+            return iterable.sort(compare);
+        }
+
+        template<typename T>
+        auto operator()(std::list<T>& iterable) const
+            -> void
+        {
+            return iterable.sort();
+        }
+
+        template<
+            typename T,
+            typename Compare,
+            typename = std::enable_if_t<not is_projection_v<Compare, std::list<T>&>>
+        >
+        auto operator()(std::list<T>& iterable, Compare compare) const
+            -> void
+        {
+            return iterable.sort(compare);
+        }
+
+        ////////////////////////////////////////////////////////////
+        // Sorter traits
+
+        using is_always_stable = std::true_type;
     };
 }
 

--- a/include/cpp-sort/detail/stable_adapter_self_sort_adapter.h
+++ b/include/cpp-sort/detail/stable_adapter_self_sort_adapter.h
@@ -66,7 +66,7 @@ namespace cppsort
             ////////////////////////////////////////////////////////////
             // Sorter traits
 
-            using is_stable = std::true_type;
+            using is_always_stable = std::true_type;
     };
 }
 

--- a/include/cpp-sort/fixed/low_comparisons_sorter.h
+++ b/include/cpp-sort/fixed/low_comparisons_sorter.h
@@ -66,7 +66,7 @@ namespace cppsort
         // the stability *could* be documented depending on which
         // fixed-size algorithms are used, but it would be lots of
         // work...
-        using is_stable = std::false_type;
+        using is_always_stable = std::false_type;
     };
 
     template<>
@@ -74,7 +74,7 @@ namespace cppsort
     {
         using domain = std::make_index_sequence<14>;
         using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
+        using is_always_stable = std::false_type;
     };
 }
 

--- a/include/cpp-sort/fixed/low_moves_sorter.h
+++ b/include/cpp-sort/fixed/low_moves_sorter.h
@@ -118,14 +118,14 @@ namespace cppsort
         // the stability *could* be documented depending on which
         // fixed-size algorithms are used, but it would be lots of
         // work...
-        using is_stable = std::false_type;
+        using is_always_stable = std::false_type;
     };
 
     template<>
     struct fixed_sorter_traits<low_moves_sorter>
     {
         using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
+        using is_always_stable = std::false_type;
     };
 }
 

--- a/include/cpp-sort/fixed/sorting_network_sorter.h
+++ b/include/cpp-sort/fixed/sorting_network_sorter.h
@@ -66,7 +66,7 @@ namespace cppsort
         // the stability *could* be documented depending on which
         // fixed-size algorithms are used, but it would be lots of
         // work...
-        using is_stable = std::false_type;
+        using is_always_stable = std::false_type;
     };
 
     template<>
@@ -74,7 +74,7 @@ namespace cppsort
     {
         using domain = std::make_index_sequence<33>;
         using iterator_category = std::random_access_iterator_tag;
-        using is_stable = std::false_type;
+        using is_always_stable = std::false_type;
     };
 }
 

--- a/include/cpp-sort/sorter_traits.h
+++ b/include/cpp-sort/sorter_traits.h
@@ -242,6 +242,18 @@ namespace cppsort
     using is_always_stable = typename sorter_traits<Sorter>::is_always_stable;
 
     ////////////////////////////////////////////////////////////
+    // Whether a sorter is stable when called with parameter of
+    // specific types
+
+    template<typename>
+    struct is_stable;
+
+    template<typename Sorter, typename... Args>
+    struct is_stable<Sorter(Args...)>:
+        sorter_traits<Sorter>::is_always_stable
+    {};
+
+    ////////////////////////////////////////////////////////////
     // Fixed-size sorter traits
 
     template<template<std::size_t> class FixedSizeSorter>

--- a/include/cpp-sort/sorter_traits.h
+++ b/include/cpp-sort/sorter_traits.h
@@ -232,14 +232,14 @@ namespace cppsort
     template<typename Sorter>
     struct sorter_traits:
         detail::raw_check_iterator_category<Sorter>,
-        detail::raw_check_is_stable<Sorter>
+        detail::raw_check_is_always_stable<Sorter>
     {};
 
     template<typename Sorter>
     using iterator_category = typename sorter_traits<Sorter>::iterator_category;
 
     template<typename Sorter>
-    using is_stable = typename sorter_traits<Sorter>::is_stable;
+    using is_always_stable = typename sorter_traits<Sorter>::is_always_stable;
 
     ////////////////////////////////////////////////////////////
     // Fixed-size sorter traits

--- a/include/cpp-sort/sorters/block_sorter.h
+++ b/include/cpp-sort/sorters/block_sorter.h
@@ -75,7 +75,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::true_type;
+            using is_always_stable = std::true_type;
         };
     }
 

--- a/include/cpp-sort/sorters/counting_sorter.h
+++ b/include/cpp-sort/sorters/counting_sorter.h
@@ -66,7 +66,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::forward_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/grail_sorter.h
+++ b/include/cpp-sort/sorters/grail_sorter.h
@@ -74,7 +74,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::true_type;
+            using is_always_stable = std::true_type;
         };
     }
 

--- a/include/cpp-sort/sorters/heap_sorter.h
+++ b/include/cpp-sort/sorters/heap_sorter.h
@@ -73,7 +73,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/insertion_sorter.h
+++ b/include/cpp-sort/sorters/insertion_sorter.h
@@ -73,7 +73,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::forward_iterator_tag;
-            using is_stable = std::true_type;
+            using is_always_stable = std::true_type;
         };
     }
 

--- a/include/cpp-sort/sorters/merge_insertion_sorter.h
+++ b/include/cpp-sort/sorters/merge_insertion_sorter.h
@@ -73,7 +73,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/merge_sorter.h
+++ b/include/cpp-sort/sorters/merge_sorter.h
@@ -101,7 +101,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::forward_iterator_tag;
-            using is_stable = std::true_type;
+            using is_always_stable = std::true_type;
         };
     }
 

--- a/include/cpp-sort/sorters/pdq_sorter.h
+++ b/include/cpp-sort/sorters/pdq_sorter.h
@@ -73,7 +73,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/poplar_sorter.h
+++ b/include/cpp-sort/sorters/poplar_sorter.h
@@ -73,7 +73,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/quick_sorter.h
+++ b/include/cpp-sort/sorters/quick_sorter.h
@@ -101,7 +101,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::forward_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/selection_sorter.h
+++ b/include/cpp-sort/sorters/selection_sorter.h
@@ -73,7 +73,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::forward_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/smooth_sorter.h
+++ b/include/cpp-sort/sorters/smooth_sorter.h
@@ -73,7 +73,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/spread_sorter/float_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/float_spread_sorter.h
@@ -67,7 +67,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/spread_sorter/integer_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/integer_spread_sorter.h
@@ -68,7 +68,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/spread_sorter/string_spread_sorter.h
+++ b/include/cpp-sort/sorters/spread_sorter/string_spread_sorter.h
@@ -125,7 +125,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/include/cpp-sort/sorters/std_sorter.h
+++ b/include/cpp-sort/sorters/std_sorter.h
@@ -72,7 +72,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 
@@ -113,7 +113,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::true_type;
+            using is_always_stable = std::true_type;
         };
     }
 

--- a/include/cpp-sort/sorters/tim_sorter.h
+++ b/include/cpp-sort/sorters/tim_sorter.h
@@ -73,7 +73,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::random_access_iterator_tag;
-            using is_stable = std::true_type;
+            using is_always_stable = std::true_type;
         };
     }
 

--- a/include/cpp-sort/sorters/verge_sorter.h
+++ b/include/cpp-sort/sorters/verge_sorter.h
@@ -73,7 +73,7 @@ namespace cppsort
             // Sorter traits
 
             using iterator_category = std::bidirectional_iterator_tag;
-            using is_stable = std::false_type;
+            using is_always_stable = std::false_type;
         };
     }
 

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -10,6 +10,7 @@ set(
     adapters/container_aware_adapter_list.cpp
     adapters/container_aware_adapter_forward_list.cpp
     adapters/counting_adapter.cpp
+    adapters/hybrid_adapter_is_stable.cpp
     adapters/hybrid_adapter_partial_compare.cpp
     adapters/hybrid_adapter_sfinae.cpp
     adapters/indirect_adapter.cpp

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(
     every_sorter.cpp
     every_sorter_move_only.cpp
     every_sorter_span.cpp
+    is_stable.cpp
     rebind_iterator_category.cpp
     sorter_facade.cpp
     sorter_facade_defaults.cpp

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -20,6 +20,7 @@ set(
     adapters/self_sort_adapter.cpp
     adapters/self_sort_adapter_no_compare.cpp
     adapters/small_array_adapter.cpp
+    adapters/small_array_adapter_is_stable.cpp
     adapters/stable_adapter_every_sorter.cpp
 )
 

--- a/testsuite/adapters/container_aware_adapter.cpp
+++ b/testsuite/adapters/container_aware_adapter.cpp
@@ -26,7 +26,7 @@
 #include <catch.hpp>
 #include <cpp-sort/adapters/container_aware_adapter.h>
 #include <cpp-sort/sort.h>
-#include <cpp-sort/sorters/selection_sorter.h>
+#include <cpp-sort/sorters/merge_sorter.h>
 #include "../algorithm.h"
 
 namespace foobar
@@ -45,7 +45,7 @@ namespace foobar
             not cppsort::is_projection<Compare, T>::value
         >
     >
-    auto sort(cppsort::selection_sorter, cool_list<T>&, Compare)
+    auto sort(cppsort::merge_sorter, cool_list<T>&, Compare)
         -> bool
     {
         return true;
@@ -56,7 +56,7 @@ TEST_CASE( "basic tests with container_aware_adapter",
            "[container_aware_adapter]" )
 {
     using sorter = cppsort::container_aware_adapter<
-        cppsort::selection_sorter
+        cppsort::merge_sorter
     >;
 
     // Cool list to "sort"
@@ -66,17 +66,28 @@ TEST_CASE( "basic tests with container_aware_adapter",
     {
         CHECK( sorter{}(collection, std::greater<>{}) );
         CHECK( cppsort::sort(sorter{}, collection, std::greater<>{}) );
+        CHECK( not cppsort::is_stable<sorter(foobar::cool_list<int>&, std::greater<>)>::value );
     }
 
     SECTION( "with projection" )
     {
         CHECK( sorter{}(collection, std::negate<>{}) );
         CHECK( cppsort::sort(sorter{}, collection, std::negate<>{}) );
+        CHECK( not cppsort::is_stable<sorter(foobar::cool_list<int>&, std::negate<>)>::value );
     }
 
     SECTION( "with automagic comparison-projection" )
     {
         CHECK( sorter{}(collection, std::greater<>{}, std::negate<>{}) );
         CHECK( cppsort::sort(sorter{}, collection, std::greater<>{}, std::negate<>{}) );
+        CHECK( not cppsort::is_stable<sorter(foobar::cool_list<int>&, std::greater<>, std::negate<>)>::value );
+    }
+
+    SECTION( "more about stability" )
+    {
+        CHECK( cppsort::is_stable<sorter(std::list<int>&)>::value );
+        CHECK( cppsort::is_stable<sorter(std::list<int>::iterator, std::list<int>::iterator)>::value );
+        CHECK( cppsort::is_stable<sorter(foobar::cool_list<int>::iterator,
+                                         foobar::cool_list<int>::iterator)>::value );
     }
 }

--- a/testsuite/adapters/hybrid_adapter_is_stable.cpp
+++ b/testsuite/adapters/hybrid_adapter_is_stable.cpp
@@ -1,0 +1,123 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <forward_list>
+#include <iterator>
+#include <list>
+#include <vector>
+#include <cpp-sort/adapters/hybrid_adapter.h>
+#include <cpp-sort/adapters/small_array_adapter.h>
+#include <cpp-sort/fixed/sorting_network_sorter.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/sorters/merge_sorter.h>
+#include <cpp-sort/sorters/pdq_sorter.h>
+#include <cpp-sort/sorters/selection_sorter.h>
+#include <catch.hpp>
+
+TEST_CASE( "hybrid_adapter stability checks",
+           "[hybrid_adapter][is_stable]" )
+{
+    SECTION( "simple sorters" )
+    {
+        using sorter = cppsort::hybrid_adapter<
+            cppsort::selection_sorter,
+            cppsort::rebind_iterator_category<
+                cppsort::merge_sorter,
+                std::bidirectional_iterator_tag
+            >,
+            cppsort::pdq_sorter
+        >;
+
+        CHECK(( not cppsort::is_stable<sorter(std::vector<int>&)>::value ));
+        CHECK(( not cppsort::is_stable<sorter(std::vector<int>::iterator,
+                                              std::vector<int>::iterator)>::value ));
+
+        CHECK(( cppsort::is_stable<sorter(std::list<int>&)>::value ));
+        CHECK(( cppsort::is_stable<sorter(std::list<int>::iterator,
+                                          std::list<int>::iterator)>::value ));
+
+        CHECK(( not cppsort::is_stable<sorter(std::forward_list<int>&)>::value ));
+        CHECK(( not cppsort::is_stable<sorter(std::forward_list<int>::iterator,
+                                              std::forward_list<int>::iterator)>::value ));
+    }
+
+    SECTION( "nested hybrid_adapter" )
+    {
+        using sorter = cppsort::hybrid_adapter<
+            cppsort::selection_sorter,
+            cppsort::hybrid_adapter<
+                cppsort::rebind_iterator_category<
+                    cppsort::merge_sorter,
+                    std::bidirectional_iterator_tag
+                >
+            >,
+            cppsort::pdq_sorter
+        >;
+
+        CHECK(( not cppsort::is_stable<sorter(std::vector<int>&)>::value ));
+        CHECK(( not cppsort::is_stable<sorter(std::vector<int>::iterator,
+                                              std::vector<int>::iterator)>::value ));
+
+        CHECK(( cppsort::is_stable<sorter(std::list<int>&)>::value ));
+        CHECK(( cppsort::is_stable<sorter(std::list<int>::iterator,
+                                          std::list<int>::iterator)>::value ));
+
+        CHECK(( not cppsort::is_stable<sorter(std::forward_list<int>&)>::value ));
+        CHECK(( not cppsort::is_stable<sorter(std::forward_list<int>::iterator,
+                                              std::forward_list<int>::iterator)>::value ));
+    }
+
+    SECTION( "with small_array_adapter" )
+    {
+        using sorter = cppsort::hybrid_adapter<
+            cppsort::small_array_adapter<
+                cppsort::sorting_network_sorter,
+                std::make_index_sequence<14u>
+            >,
+            cppsort::merge_sorter
+        >;
+
+        CHECK(( cppsort::is_stable<sorter(std::vector<int>&)>::value ));
+        CHECK(( cppsort::is_stable<sorter(std::vector<int>::iterator,
+                                          std::vector<int>::iterator)>::value ));
+
+        CHECK(( cppsort::is_stable<sorter(std::list<int>&)>::value ));
+        CHECK(( cppsort::is_stable<sorter(std::list<int>::iterator,
+                                          std::list<int>::iterator)>::value ));
+
+        CHECK(( cppsort::is_stable<sorter(std::forward_list<int>&)>::value ));
+        CHECK(( cppsort::is_stable<sorter(std::forward_list<int>::iterator,
+                                          std::forward_list<int>::iterator)>::value ));
+
+        CHECK(( not cppsort::is_stable<sorter(std::array<int, 5>&)>::value ));
+        CHECK(( cppsort::is_stable<sorter(std::array<int, 5>::iterator,
+                                          std::array<int, 5>::iterator)>::value ));
+
+        CHECK(( cppsort::is_stable<sorter(std::array<int, 16>&)>::value ));
+        CHECK(( cppsort::is_stable<sorter(std::array<int, 16>::iterator,
+                                          std::array<int, 16>::iterator)>::value ));
+
+        CHECK(( not cppsort::is_stable<sorter(int(&)[8])>::value ));
+        CHECK(( cppsort::is_stable<sorter(int(&)[20])>::value ));
+    }
+}

--- a/testsuite/adapters/mixed_adapters.cpp
+++ b/testsuite/adapters/mixed_adapters.cpp
@@ -133,24 +133,32 @@ TEST_CASE( "stability of counting_adapter over self_sort_adapter",
 
     SECTION( "is_stable" )
     {
-        CHECK( not cppsort::is_stable<sorter1(std::list<int>&)>::value );
+        CHECK( cppsort::is_stable<sorter1(std::list<int>&)>::value );
         CHECK( not cppsort::is_stable<sorter1(std::vector<int>&)>::value );
-        CHECK( not cppsort::is_stable<sorter1(std::list<int>&, std::greater<>)>::value );
+        CHECK( cppsort::is_stable<sorter1(std::list<int>&, std::greater<>)>::value );
         CHECK( not cppsort::is_stable<sorter1(std::vector<int>&, std::greater<>)>::value );
+        CHECK( not cppsort::is_stable<sorter1(std::list<int>&, std::negate<>)>::value );
+        CHECK( not cppsort::is_stable<sorter1(std::vector<int>&, std::negate<>)>::value );
 
         CHECK( not cppsort::is_stable<sorter1(std::list<int>::iterator, std::list<int>::iterator)>::value );
         CHECK( not cppsort::is_stable<sorter1(std::vector<int>::iterator, std::vector<int>::iterator)>::value );
         CHECK( not cppsort::is_stable<sorter1(std::list<int>::iterator, std::list<int>::iterator, std::greater<>)>::value );
         CHECK( not cppsort::is_stable<sorter1(std::vector<int>::iterator, std::vector<int>::iterator, std::greater<>)>::value );
+        CHECK( not cppsort::is_stable<sorter1(std::list<int>::iterator, std::list<int>::iterator, std::negate<>)>::value );
+        CHECK( not cppsort::is_stable<sorter1(std::vector<int>::iterator, std::vector<int>::iterator, std::negate<>)>::value );
 
-        CHECK( not cppsort::is_stable<sorter2(std::list<int>&)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::list<int>&)>::value );
         CHECK( cppsort::is_stable<sorter2(std::vector<int>&)>::value );
-        CHECK( not cppsort::is_stable<sorter2(std::list<int>&, std::greater<>)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::list<int>&, std::greater<>)>::value );
         CHECK( cppsort::is_stable<sorter2(std::vector<int>&, std::greater<>)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::list<int>&, std::negate<>)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::vector<int>&, std::negate<>)>::value );
 
         CHECK( cppsort::is_stable<sorter2(std::list<int>::iterator, std::list<int>::iterator)>::value );
         CHECK( cppsort::is_stable<sorter2(std::vector<int>::iterator, std::vector<int>::iterator)>::value );
         CHECK( cppsort::is_stable<sorter2(std::list<int>::iterator, std::list<int>::iterator, std::greater<>)>::value );
         CHECK( cppsort::is_stable<sorter2(std::vector<int>::iterator, std::vector<int>::iterator, std::greater<>)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::list<int>::iterator, std::list<int>::iterator, std::negate<>)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::vector<int>::iterator, std::vector<int>::iterator, std::negate<>)>::value );
     }
 }

--- a/testsuite/adapters/mixed_adapters.cpp
+++ b/testsuite/adapters/mixed_adapters.cpp
@@ -25,12 +25,15 @@
 #include <ctime>
 #include <functional>
 #include <iterator>
+#include <list>
 #include <random>
 #include <vector>
 #include <catch.hpp>
+#include <cpp-sort/adapters/counting_adapter.h>
 #include <cpp-sort/adapters/indirect_adapter.h>
 #include <cpp-sort/adapters/schwartz_adapter.h>
 #include <cpp-sort/sort.h>
+#include <cpp-sort/sorters/insertion_sorter.h>
 #include <cpp-sort/sorters/selection_sorter.h>
 #include "../algorithm.h"
 
@@ -98,5 +101,56 @@ TEST_CASE( "indirect sort with Schwartzian transform",
         cppsort::sort(sorter{}, collection, &wrapper::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
                                   std::less<>{}, &wrapper::value) );
+    }
+}
+
+//
+// Stability of mixed adapters without dedicated specializations
+//
+
+TEST_CASE( "stability of counting_adapter over self_sort_adapter",
+           "[counting_adapter][is_stable]" )
+{
+    // Big checks to ensure that mixed sorters have a valid stability
+
+    using sorter1 = cppsort::counting_adapter<
+        cppsort::self_sort_adapter<
+            cppsort::selection_sorter
+        >
+    >;
+
+    using sorter2 = cppsort::counting_adapter<
+        cppsort::self_sort_adapter<
+            cppsort::insertion_sorter
+        >
+    >;
+
+    SECTION( "is_always_stable" )
+    {
+        CHECK( not cppsort::is_always_stable<sorter1>::value );
+        CHECK( not cppsort::is_always_stable<sorter2>::value );
+    }
+
+    SECTION( "is_stable" )
+    {
+        CHECK( not cppsort::is_stable<sorter1(std::list<int>&)>::value );
+        CHECK( not cppsort::is_stable<sorter1(std::vector<int>&)>::value );
+        CHECK( not cppsort::is_stable<sorter1(std::list<int>&, std::greater<>)>::value );
+        CHECK( not cppsort::is_stable<sorter1(std::vector<int>&, std::greater<>)>::value );
+
+        CHECK( not cppsort::is_stable<sorter1(std::list<int>::iterator, std::list<int>::iterator)>::value );
+        CHECK( not cppsort::is_stable<sorter1(std::vector<int>::iterator, std::vector<int>::iterator)>::value );
+        CHECK( not cppsort::is_stable<sorter1(std::list<int>::iterator, std::list<int>::iterator, std::greater<>)>::value );
+        CHECK( not cppsort::is_stable<sorter1(std::vector<int>::iterator, std::vector<int>::iterator, std::greater<>)>::value );
+
+        CHECK( not cppsort::is_stable<sorter2(std::list<int>&)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::vector<int>&)>::value );
+        CHECK( not cppsort::is_stable<sorter2(std::list<int>&, std::greater<>)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::vector<int>&, std::greater<>)>::value );
+
+        CHECK( cppsort::is_stable<sorter2(std::list<int>::iterator, std::list<int>::iterator)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::vector<int>::iterator, std::vector<int>::iterator)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::list<int>::iterator, std::list<int>::iterator, std::greater<>)>::value );
+        CHECK( cppsort::is_stable<sorter2(std::vector<int>::iterator, std::vector<int>::iterator, std::greater<>)>::value );
     }
 }

--- a/testsuite/adapters/schwartz_adapter_fixed_sorters.cpp
+++ b/testsuite/adapters/schwartz_adapter_fixed_sorters.cpp
@@ -180,3 +180,22 @@ TEST_CASE( "Schwartzian transform adapter with fixed-size sorters",
                                   std::less<>{}, &wrapper::value) );
     }
 }
+
+TEST_CASE( "stability of Schwartzian transform adapter with fixed-size sorters",
+           "[schwartz_adapter][is_stable]" )
+{
+    struct wrapper { double value; };
+
+    using namespace cppsort;
+    using sorter = schwartz_adapter<
+        small_array_adapter<
+            low_moves_sorter
+        >
+    >;
+
+    SECTION( "is_always_stable" )
+    {
+        CHECK( not is_always_stable<small_array_adapter<low_moves_sorter>>::value );
+        CHECK( not is_always_stable<sorter>::value );
+    }
+}

--- a/testsuite/adapters/self_sort_adapter.cpp
+++ b/testsuite/adapters/self_sort_adapter.cpp
@@ -77,7 +77,7 @@ namespace
             return kind::sorter;
         }
 
-        using is_stable = std::true_type;
+        using is_always_stable = std::true_type;
     };
 
     struct dumb_sorter:

--- a/testsuite/adapters/small_array_adapter_is_stable.cpp
+++ b/testsuite/adapters/small_array_adapter_is_stable.cpp
@@ -1,0 +1,139 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <type_traits>
+#include <catch.hpp>
+#include <cpp-sort/adapters/schwartz_adapter.h>
+#include <cpp-sort/adapters/small_array_adapter.h>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+
+namespace
+{
+    template<std::size_t N>
+    struct fixed_sorter_impl
+    {
+        template<
+            typename RandomAccessIterator,
+            typename Compare = std::less<>
+        >
+        auto operator()(RandomAccessIterator, RandomAccessIterator, Compare={}) const
+            -> void
+        {}
+
+        using is_always_stable = std::false_type;
+    };
+
+    template<std::size_t N>
+    struct fixed_sorter_with_domain_impl
+    {
+        template<
+            typename RandomAccessIterator,
+            typename Compare = std::less<>,
+            typename Projection = cppsort::utility::identity,
+            typename = std::enable_if_t<cppsort::is_projection_iterator_v<
+                Projection, RandomAccessIterator, Compare
+            >>
+        >
+        auto operator()(RandomAccessIterator, RandomAccessIterator,
+                        Compare={}, Projection={}) const
+            -> void
+        {}
+
+        using is_always_stable = std::true_type;
+    };
+
+    template<std::size_t N>
+    struct fixed_sorter:
+        cppsort::sorter_facade<fixed_sorter_impl<N>>
+    {};
+
+    template<std::size_t N>
+    struct fixed_sorter_with_domain:
+        cppsort::sorter_facade<fixed_sorter_with_domain_impl<N>>
+    {};
+}
+
+namespace cppsort
+{
+    template<>
+    struct fixed_sorter_traits<fixed_sorter>
+    {
+        using is_always_stable = std::false_type;
+        using iterator_category = std::random_access_iterator_tag;
+    };
+
+    template<>
+    struct fixed_sorter_traits<fixed_sorter_with_domain>
+    {
+        using domain = std::make_index_sequence<9>;
+        using is_always_stable = std::true_type;
+        using iterator_category = std::random_access_iterator_tag;
+    };
+}
+
+TEST_CASE( "small_array_adapter stability",
+           "[small_array_adapter][schwartz_adapter][is_stable]" )
+{
+    std::array<int, 6u> array;
+    int big_array[25u];
+
+    using sorter1 = cppsort::small_array_adapter<fixed_sorter>;
+    using sorter2 = cppsort::small_array_adapter<fixed_sorter_with_domain>;
+
+    SECTION( "is_always_stable" )
+    {
+        CHECK( not cppsort::is_always_stable<sorter1>::value );
+        CHECK( cppsort::is_always_stable<sorter2>::value );
+    }
+
+    SECTION( "is_stable" )
+    {
+        CHECK( not cppsort::is_stable<sorter1(decltype(array))>::value );
+        CHECK( not cppsort::is_stable<sorter1(decltype(big_array))>::value );
+        CHECK( not cppsort::is_stable<sorter1(decltype(array), std::less<>)>::value );
+        CHECK( not cppsort::is_stable<sorter1(decltype(big_array), std::less<>)>::value );
+
+        CHECK( cppsort::is_stable<sorter2(decltype(array))>::value );
+        CHECK( cppsort::is_stable<sorter2(decltype(array), std::less<>)>::value );
+        CHECK( cppsort::is_stable<sorter2(decltype(array), std::negate<>)>::value );
+    }
+
+    SECTION( "is_stable with schwartz_adapter" )
+    {
+        using sorter3 = cppsort::schwartz_adapter<sorter1>;
+        using sorter4 = cppsort::schwartz_adapter<sorter2>;
+
+        CHECK( not cppsort::is_stable<sorter3(decltype(array))>::value );
+        CHECK( not cppsort::is_stable<sorter3(decltype(big_array))>::value );
+        CHECK( not cppsort::is_stable<sorter3(decltype(array), std::less<>)>::value );
+        CHECK( not cppsort::is_stable<sorter3(decltype(big_array), std::less<>)>::value );
+
+        CHECK( cppsort::is_stable<sorter4(decltype(array))>::value );
+        CHECK( cppsort::is_stable<sorter4(decltype(array), std::less<>)>::value );
+        CHECK( cppsort::is_stable<sorter4(decltype(array), std::negate<>)>::value );
+    }
+}

--- a/testsuite/is_stable.cpp
+++ b/testsuite/is_stable.cpp
@@ -1,0 +1,129 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <functional>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/fixed/low_comparisons_sorter.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/sorters/merge_sorter.h>
+#include <cpp-sort/sorters/quick_sorter.h>
+#include <cpp-sort/utility/functional.h>
+
+TEST_CASE( "test is_stable with raw sorters",
+           "[is_stable]" )
+{
+    // Exhaustive test for every scenario where is_sorter is
+    // supposed to trivially fall back to is_always_stable
+
+    using cppsort::is_stable;
+    using cppsort::utility::identity;
+
+    SECTION( "merge_sorter" )
+    {
+        using sorter = cppsort::merge_sorter;
+
+        CHECK(( is_stable<sorter(std::vector<int>&)>::value ));
+        CHECK(( is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator)>::value ));
+
+        CHECK(( is_stable<sorter(std::vector<int>&, std::less<>)>::value ));
+        CHECK(( is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                 std::less<>)>::value ));
+
+        CHECK(( is_stable<sorter(std::vector<int>&, std::greater<>)>::value ));
+        CHECK(( is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                 std::greater<>)>::value ));
+
+        CHECK(( is_stable<sorter(std::vector<int>&, identity)>::value ));
+        CHECK(( is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                 identity)>::value ));
+
+        CHECK(( is_stable<sorter(std::vector<int>&, std::negate<>)>::value ));
+        CHECK(( is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                 std::negate<>)>::value ));
+
+        CHECK(( is_stable<sorter(std::vector<int>&, std::less<>, identity)>::value ));
+        CHECK(( is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                 std::less<>, identity)>::value ));
+
+        CHECK(( is_stable<sorter(std::vector<int>&, std::greater<>, identity)>::value ));
+        CHECK(( is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                 std::greater<>, identity)>::value ));
+
+        CHECK(( is_stable<sorter(std::vector<int>&, std::less<>, std::negate<>)>::value ));
+        CHECK(( is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                 std::less<>, std::negate<>)>::value ));
+
+        CHECK(( is_stable<sorter(std::vector<int>&, std::greater<>, std::negate<>)>::value ));
+        CHECK(( is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                 std::greater<>, std::negate<>)>::value ));
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        using sorter = cppsort::quick_sorter;
+
+        CHECK(( not is_stable<sorter(std::vector<int>&)>::value ));
+        CHECK(( not is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator)>::value ));
+
+        CHECK(( not is_stable<sorter(std::vector<int>&, std::less<>)>::value ));
+        CHECK(( not is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                     std::less<>)>::value ));
+
+        CHECK(( not is_stable<sorter(std::vector<int>&, std::greater<>)>::value ));
+        CHECK(( not is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                     std::greater<>)>::value ));
+
+        CHECK(( not is_stable<sorter(std::vector<int>&, identity)>::value ));
+        CHECK(( not is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                     identity)>::value ));
+
+        CHECK(( not is_stable<sorter(std::vector<int>&, std::negate<>)>::value ));
+        CHECK(( not is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                     std::negate<>)>::value ));
+
+        CHECK(( not is_stable<sorter(std::vector<int>&, std::less<>, identity)>::value ));
+        CHECK(( not is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                     std::less<>, identity)>::value ));
+
+        CHECK(( not is_stable<sorter(std::vector<int>&, std::greater<>, identity)>::value ));
+        CHECK(( not is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                     std::greater<>, identity)>::value ));
+
+        CHECK(( not is_stable<sorter(std::vector<int>&, std::less<>, std::negate<>)>::value ));
+        CHECK(( not is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                     std::less<>, std::negate<>)>::value ));
+
+        CHECK(( not is_stable<sorter(std::vector<int>&, std::greater<>, std::negate<>)>::value ));
+        CHECK(( not is_stable<sorter(std::vector<int>::iterator, std::vector<int>::iterator,
+                                     std::greater<>, std::negate<>)>::value ));
+    }
+
+    SECTION( "low_comparisons_sorter" )
+    {
+        // Many fixed-size sorters define is_always_stable through
+        // sorter_traits, which makes this test interesting
+        using sorter = cppsort::low_comparisons_sorter<8>;
+        CHECK( not is_stable<sorter(int(&)[8])>::value );
+    }
+}


### PR DESCRIPTION
A pull request all about `is_stable`:
* The old `is_stable` was changed to `is_always_stable` *everywhere*.
* A new `is_stable<Sorter(Args..)>` was introduced to tell whether a sorter is stable when called with a specific set of parameters.
* `is_stable` has flexible specializations for every sorter adapter.
* `stable_adapter` uses `is_stable` instead of `is_always_stable` to delay the stability check to the call site, making it use `make_stable` less often.

tl;dr: `stable_adapter` needs to use `make_stable` less often.