### PR TITLE
as_comparison and as_projection (fixes #79)

### DIFF
--- a/include/cpp-sort/adapters/container_aware_adapter.h
+++ b/include/cpp-sort/adapters/container_aware_adapter.h
@@ -184,6 +184,7 @@ namespace cppsort
             >
             auto operator()(Iterable& iterable, Projection projection) const
                 -> std::enable_if_t<
+                    not detail::can_comparison_sort<Sorter, Iterable, Projection>::value &&
                     detail::can_projection_sort<Sorter, Iterable, Projection>::value,
                     std::conditional_t<
                         Stability,

--- a/include/cpp-sort/sort.h
+++ b/include/cpp-sort/sort.h
@@ -62,7 +62,8 @@ namespace cppsort
         typename = std::enable_if_t<
             not is_comparison_sorter_v<Iterable, Compare, Projection> &&
             not is_projection_sorter_v<Iterable, Compare, Projection> &&
-            not is_sorter_iterator_v<Iterable, Compare>
+            not is_sorter_iterator_v<Iterable, Compare> &&
+            is_projection_v<Projection, Iterable, Compare>
         >
     >
     auto sort(Iterable&& iterable, Compare compare, Projection projection)
@@ -80,13 +81,13 @@ namespace cppsort
 
     template<
         typename Iterator,
-        typename Compare,
-        typename = std::enable_if_t<not is_sorter_iterator_v<Iterator, Compare>>
+        typename Func,
+        typename = std::enable_if_t<not is_sorter_iterator_v<Iterator, Func>>
     >
-    auto sort(Iterator first, Iterator last, Compare compare)
+    auto sort(Iterator first, Iterator last, Func func)
         -> void
     {
-        default_sorter{}(first, last, compare);
+        default_sorter{}(first, last, func);
     }
 
     template<

--- a/include/cpp-sort/sorter_facade.h
+++ b/include/cpp-sort/sorter_facade.h
@@ -232,6 +232,7 @@ namespace cppsort
             template<typename Iterator, typename Projection>
             auto operator()(Iterator first, Iterator last, Projection projection) const
                 -> std::enable_if_t<
+                    not detail::has_comparison_sort_iterator<Sorter, Iterator, Projection>::value &&
                     detail::has_projection_sort_iterator<Sorter, Iterator, Projection>::value,
                     decltype(Sorter::operator()(first, last, projection))
                 >
@@ -253,6 +254,7 @@ namespace cppsort
             template<typename Iterable, typename Projection>
             auto operator()(Iterable&& iterable, Projection projection) const
                 -> std::enable_if_t<
+                    not detail::has_comparison_sort<Sorter, Iterable, Projection>::value &&
                     detail::has_projection_sort<Sorter, Iterable, Projection>::value,
                     decltype(Sorter::operator()(std::forward<Iterable>(iterable), projection))
                 >
@@ -274,6 +276,8 @@ namespace cppsort
             template<typename Iterable, typename Projection>
             auto operator()(Iterable&& iterable, Projection projection) const
                 -> std::enable_if_t<
+                    not detail::has_comparison_sort<Sorter, Iterable, Projection>::value &&
+                    not detail::has_comparison_sort_iterator<Sorter, decltype(utility::begin(iterable)), Projection>::value &&
                     not detail::has_projection_sort<Sorter, Iterable, Projection>::value &&
                     not detail::has_comparison_projection_sort<Sorter, Iterable, std::less<>, Projection>::value &&
                         detail::has_projection_sort_iterator<Sorter, decltype(utility::begin(iterable)), Projection>::value,

--- a/include/cpp-sort/stable_sort.h
+++ b/include/cpp-sort/stable_sort.h
@@ -32,6 +32,7 @@
 #include <cpp-sort/adapters/stable_adapter.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/sorters/default_sorter.h>
+#include <cpp-sort/utility/logical_traits.h>
 
 namespace cppsort
 {
@@ -48,7 +49,7 @@ namespace cppsort
     template<
         typename Iterable,
         typename Compare,
-        typename = std::enable_if_t<not is_sorter_v<Compare, Iterable>>
+        typename = std::enable_if_t<not is_sorter_v<Iterable, Compare>>
     >
     auto stable_sort(Iterable&& iterable, Compare compare)
         -> void
@@ -110,9 +111,9 @@ namespace cppsort
     template<
         typename Sorter,
         typename Iterable,
-        typename = std::enable_if_t<is_sorter_v<
-            stable_adapter<Sorter>, Iterable
-        >>
+        typename = std::enable_if_t<
+            is_sorter_v<Sorter, Iterable>
+        >
     >
     auto stable_sort(const Sorter&, Iterable&& iterable)
         -> decltype(auto)
@@ -124,10 +125,10 @@ namespace cppsort
         typename Sorter,
         typename Iterable,
         typename Func,
-        typename = std::enable_if_t<
-            is_comparison_sorter_v<stable_adapter<Sorter>, Iterable, Func> ||
-            is_projection_sorter_v<stable_adapter<Sorter>, Iterable, Func>
-        >
+        typename = std::enable_if_t<utility::disjunction<
+            is_comparison_sorter<Sorter, Iterable, Func>,
+            is_projection_sorter<Sorter, Iterable, Func>
+        >::value>
     >
     auto stable_sort(const Sorter&, Iterable&& iterable, Func func)
         -> decltype(auto)

--- a/include/cpp-sort/utility/functional.h
+++ b/include/cpp-sort/utility/functional.h
@@ -111,9 +111,14 @@ namespace utility
                 }
         };
 
-        template<typename Function>
-        struct as_projection_fn<as_projection_fn<Function>>:
-            as_projection_fn<Function>
+        template<typename T>
+        struct is_as_projection_fn:
+            std::false_type
+        {};
+
+        template<typename T>
+        struct is_as_projection_fn<as_projection_fn<T>>:
+            std::true_type
         {};
 
         template<typename Function>
@@ -172,24 +177,55 @@ namespace utility
                 }
         };
 
-        template<typename Function>
-        struct as_comparison_fn<as_comparison_fn<Function>>:
-            as_comparison_fn<Function>
+        template<typename T>
+        struct is_as_comparison_fn:
+            std::false_type
+        {};
+
+        template<typename T>
+        struct is_as_comparison_fn<as_comparison_fn<T>>:
+            std::true_type
         {};
     }
 
     template<typename Function>
     auto as_projection(Function&& func)
-        -> detail::as_projection_fn<std::decay_t<Function>>
+        -> std::enable_if_t<
+            not detail::is_as_projection_fn<std::decay_t<Function>>::value,
+            detail::as_projection_fn<std::decay_t<Function>>
+        >
     {
         return detail::as_projection_fn<std::decay_t<Function>>(std::forward<Function>(func));
     }
 
     template<typename Function>
+    auto as_projection(Function&& func)
+        -> std::enable_if_t<
+            detail::is_as_projection_fn<std::decay_t<Function>>::value,
+            decltype(std::forward<Function>(func))
+        >
+    {
+        return std::forward<Function>(func);
+    }
+
+    template<typename Function>
     auto as_comparison(Function&& func)
-        -> detail::as_comparison_fn<std::decay_t<Function>>
+        -> std::enable_if_t<
+            not detail::is_as_comparison_fn<std::decay_t<Function>>::value,
+            detail::as_comparison_fn<std::decay_t<Function>>
+        >
     {
         return detail::as_comparison_fn<std::decay_t<Function>>(std::forward<Function>(func));
+    }
+
+    template<typename Function>
+    auto as_comparison(Function&& func)
+        -> std::enable_if_t<
+            detail::is_as_comparison_fn<std::decay_t<Function>>::value,
+            decltype(std::forward<Function>(func))
+        >
+    {
+        return std::forward<Function>(func);
     }
 
     ////////////////////////////////////////////////////////////

--- a/include/cpp-sort/utility/functional.h
+++ b/include/cpp-sort/utility/functional.h
@@ -68,7 +68,12 @@ namespace utility
                 as_projection_fn(const as_projection_fn&) = default;
                 as_projection_fn(as_projection_fn&&) = default;
 
-                template<typename Func>
+                template<
+                    typename Func,
+                    typename = std::enable_if_t<
+                        not std::is_same<std::decay_t<Func>, as_projection_fn>::value
+                    >
+                >
                 explicit as_projection_fn(Func&& func):
                     _func(std::forward<Func>(func))
                 {}
@@ -124,7 +129,12 @@ namespace utility
                 as_comparison_fn(const as_comparison_fn&) = default;
                 as_comparison_fn(as_comparison_fn&&) = default;
 
-                template<typename Func>
+                template<
+                    typename Func,
+                    typename = std::enable_if_t<
+                        not std::is_same<std::decay_t<Func>, as_comparison_fn>::value
+                    >
+                >
                 explicit as_comparison_fn(Func&& func):
                     _func(std::forward<Func>(func))
                 {}

--- a/include/cpp-sort/utility/functional.h
+++ b/include/cpp-sort/utility/functional.h
@@ -62,16 +62,16 @@ namespace utility
 
                 Function _func;
 
-                template<typename Func>
-                explicit as_projection_fn(Func&& func):
-                    _func(std::forward<Func>(func))
-                {}
-
             public:
 
                 as_projection_fn() = delete;
                 as_projection_fn(const as_projection_fn&) = default;
                 as_projection_fn(as_projection_fn&&) = default;
+
+                template<typename Func>
+                explicit as_projection_fn(Func&& func):
+                    _func(std::forward<Func>(func))
+                {}
 
                 template<typename T>
                 auto operator()(T&& arg) &
@@ -97,7 +97,6 @@ namespace utility
                     return _func(std::forward<T>(arg));
                 }
 
-
                 template<typename T>
                 auto operator()(T&& arg) const&&
                     noexcept(noexcept(std::move(_func)(std::forward<T>(arg))))
@@ -111,6 +110,62 @@ namespace utility
         struct as_projection_fn<as_projection_fn<Function>>:
             as_projection_fn<Function>
         {};
+
+        template<typename Function>
+        struct as_comparison_fn
+        {
+            private:
+
+                Function _func;
+
+            public:
+
+                as_comparison_fn() = delete;
+                as_comparison_fn(const as_comparison_fn&) = default;
+                as_comparison_fn(as_comparison_fn&&) = default;
+
+                template<typename Func>
+                explicit as_comparison_fn(Func&& func):
+                    _func(std::forward<Func>(func))
+                {}
+
+                template<typename T, typename U>
+                auto operator()(T&& lhs, U&& rhs) &
+                    noexcept(noexcept(_func(std::forward<T>(lhs), std::forward<U>(rhs))))
+                    -> decltype(_func(std::forward<T>(lhs), std::forward<U>(rhs)))
+                {
+                    return _func(std::forward<T>(lhs), std::forward<U>(rhs));
+                }
+
+                template<typename T, typename U>
+                auto operator()(T&& lhs, U&& rhs) &&
+                    noexcept(noexcept(std::move(_func)(std::forward<T>(lhs), std::forward<U>(rhs))))
+                    -> decltype(std::move(_func)(std::forward<T>(lhs), std::forward<U>(rhs)))
+                {
+                    return std::move(_func)(std::forward<T>(lhs), std::forward<U>(rhs));
+                }
+
+                template<typename T, typename U>
+                auto operator()(T&& lhs, U&& rhs) const&
+                    noexcept(noexcept(_func(std::forward<T>(lhs), std::forward<U>(rhs))))
+                    -> decltype(_func(std::forward<T>(lhs), std::forward<U>(rhs)))
+                {
+                    return _func(std::forward<T>(lhs), std::forward<U>(rhs));
+                }
+
+                template<typename T, typename U>
+                auto operator()(T&& lhs, U&& rhs) const&&
+                    noexcept(noexcept(std::move(_func)(std::forward<T>(lhs), std::forward<U>(rhs))))
+                    -> decltype(std::move(_func)(std::forward<T>(lhs), std::forward<U>(rhs)))
+                {
+                    return std::move(_func)(std::forward<T>(lhs), std::forward<U>(rhs));
+                }
+        };
+
+        template<typename Function>
+        struct as_comparison_fn<as_comparison_fn<Function>>:
+            as_comparison_fn<Function>
+        {};
     }
 
     template<typename Function>
@@ -118,6 +173,13 @@ namespace utility
         -> detail::as_projection_fn<std::decay_t<Function>>
     {
         return detail::as_projection_fn<std::decay_t<Function>>(std::forward<Function>(func));
+    }
+
+    template<typename Function>
+    auto as_comparison(Function&& func)
+        -> detail::as_comparison_fn<std::decay_t<Function>>
+    {
+        return detail::as_comparison_fn<std::decay_t<Function>>(std::forward<Function>(func));
     }
 
     ////////////////////////////////////////////////////////////

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -69,6 +69,7 @@ set(
     UTILITY_TESTS
 
     utility/as_projection.cpp
+    utility/as_projection_iterable.cpp
     utility/buffer.cpp
     utility/iter_swap.cpp
 )

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -68,6 +68,7 @@ set(
 set(
     UTILITY_TESTS
 
+    utility/as_projection.cpp
     utility/buffer.cpp
     utility/iter_swap.cpp
 )

--- a/testsuite/sorter_facade_iterable.cpp
+++ b/testsuite/sorter_facade_iterable.cpp
@@ -25,7 +25,6 @@
 #include <iterator>
 #include <vector>
 #include <catch.hpp>
-#include <cpp-sort/adapters/hybrid_adapter.h>
 #include <cpp-sort/sort.h>
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>

--- a/testsuite/utility/as_projection.cpp
+++ b/testsuite/utility/as_projection.cpp
@@ -1,0 +1,175 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <functional>
+#include <iterator>
+#include <random>
+#include <utility>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters/pdq_sorter.h>
+#include <cpp-sort/stable_sort.h>
+#include <cpp-sort/utility/functional.h>
+
+namespace
+{
+    struct tricky_function
+    {
+        template<typename T, typename U>
+        auto operator()(T&& lhs, U&& rhs)
+            noexcept(noexcept(std::forward<T>(lhs) > std::forward<U>(rhs)))
+            -> decltype(std::forward<T>(lhs) > std::forward<U>(rhs))
+        {
+            // Compare values in reverse order
+            return std::forward<T>(lhs) > std::forward<U>(rhs);
+        }
+
+        template<typename T>
+        auto operator()(T&& value) const noexcept
+            -> decltype(std::forward<T>(value))
+        {
+            return std::forward<T>(value);
+        }
+    };
+}
+
+TEST_CASE( "try mixed comparison/projection function object",
+           "[utility][as_projection]" )
+{
+    std::vector<int> collection(100);
+    std::iota(std::begin(collection), std::end(collection), 0);
+    std::mt19937 engine(std::time(nullptr));
+    std::shuffle(std::begin(collection), std::end(collection), engine);
+
+    tricky_function func;
+
+    SECTION( "without an untransformed function" )
+    {
+        auto vec = collection;
+        cppsort::sort(vec, func);
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::sort(std::begin(vec), std::end(vec), func);
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::pdq_sort(vec, func);
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::sort(cppsort::pdq_sort, vec, func);
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::sort(cppsort::pdq_sort, std::begin(vec), std::end(vec), func);
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::stable_sort(vec, func);
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::stable_sort(std::begin(vec), std::end(vec), func);
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::stable_sort(cppsort::pdq_sort, vec, func);
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::stable_sort(cppsort::pdq_sort, std::begin(vec), std::end(vec), func);
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+    }
+
+    SECTION( "with a function wrapped in as_projection" )
+    {
+        auto vec = collection;
+        cppsort::sort(vec, cppsort::utility::as_projection(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        cppsort::sort(std::begin(vec), std::end(vec), cppsort::utility::as_projection(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        cppsort::sort(cppsort::pdq_sort, vec, cppsort::utility::as_projection(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        cppsort::sort(cppsort::pdq_sort, std::begin(vec), std::end(vec), cppsort::utility::as_projection(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        cppsort::stable_sort(vec, cppsort::utility::as_projection(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        cppsort::stable_sort(std::begin(vec), std::end(vec), cppsort::utility::as_projection(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        cppsort::stable_sort(cppsort::pdq_sort, vec, cppsort::utility::as_projection(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        cppsort::stable_sort(cppsort::pdq_sort, std::begin(vec), std::end(vec), cppsort::utility::as_projection(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+    }
+
+    SECTION( "with a function wrapped in as_comparison" )
+    {
+        auto vec = collection;
+        cppsort::sort(vec, cppsort::utility::as_comparison(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::sort(std::begin(vec), std::end(vec), cppsort::utility::as_comparison(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::sort(cppsort::pdq_sort, vec, cppsort::utility::as_comparison(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::sort(cppsort::pdq_sort, std::begin(vec), std::end(vec), cppsort::utility::as_comparison(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::stable_sort(vec, cppsort::utility::as_comparison(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::stable_sort(std::begin(vec), std::end(vec), cppsort::utility::as_comparison(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::stable_sort(cppsort::pdq_sort, vec, cppsort::utility::as_comparison(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        cppsort::stable_sort(cppsort::pdq_sort, std::begin(vec), std::end(vec), cppsort::utility::as_comparison(func));
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+    }
+}

--- a/testsuite/utility/as_projection_iterable.cpp
+++ b/testsuite/utility/as_projection_iterable.cpp
@@ -1,0 +1,227 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2016 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <random>
+#include <utility>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/functional.h>
+
+namespace
+{
+    struct tricky_function
+    {
+        template<typename T, typename U>
+        auto operator()(T&& lhs, U&& rhs)
+            noexcept(noexcept(std::forward<T>(lhs) > std::forward<U>(rhs)))
+            -> decltype(std::forward<T>(lhs) > std::forward<U>(rhs))
+        {
+            // Compare values in reverse order
+            return std::forward<T>(lhs) > std::forward<U>(rhs);
+        }
+
+        template<typename T>
+        auto operator()(T&& value) const noexcept
+            -> decltype(std::forward<T>(value))
+        {
+            return std::forward<T>(value);
+        }
+    };
+
+    enum struct call
+    {
+        iterator,
+        iterable
+    };
+
+    struct comparison_sorter_impl
+    {
+        template<
+            typename Iterator,
+            typename Compare=std::less<>,
+            typename = std::enable_if_t<cppsort::is_projection_iterator_v<
+                cppsort::utility::identity, Iterator, Compare
+            >>
+        >
+        auto operator()(Iterator first, Iterator last, Compare compare={}) const
+            -> call
+        {
+            cppsort::sort(first, last, compare);
+            return call::iterator;
+        }
+
+        template<
+            typename Iterable,
+            typename Compare=std::less<>,
+            typename = std::enable_if_t<cppsort::is_projection_v<
+                cppsort::utility::identity, Iterable, Compare
+            >>
+        >
+        auto operator()(Iterable& iterable, Compare compare={}) const
+            -> call
+        {
+            cppsort::sort(iterable, compare);
+            return call::iterable;
+        }
+    };
+
+    struct projection_sorter_impl
+    {
+        template<
+            typename Iterator,
+            typename Projection=cppsort::utility::identity,
+            typename = std::enable_if_t<cppsort::is_projection_iterator_v<
+                Projection, Iterator
+            >>
+        >
+        auto operator()(Iterator first, Iterator last, Projection projection={}) const
+            -> call
+        {
+            cppsort::sort(first, last, projection);
+            return call::iterator;
+        }
+
+        template<
+            typename Iterable,
+            typename Projection=cppsort::utility::identity,
+            typename = std::enable_if_t<cppsort::is_projection_v<
+                Projection, Iterable
+            >>
+        >
+        auto operator()(Iterable& iterable, Projection projection={}) const
+            -> call
+        {
+            cppsort::sort(iterable, projection);
+            return call::iterable;
+        }
+    };
+
+    struct comparison_sorter:
+        cppsort::sorter_facade<comparison_sorter_impl>
+    {};
+
+    struct projection_sorter:
+        cppsort::sorter_facade<projection_sorter_impl>
+    {};
+}
+
+TEST_CASE( "sorter_facade with sorters overloaded for iterables and mixed comparison/projection",
+           "[sorter_facade][compare][projection][as_projection]" )
+{
+    // Test the intersection between mixed comparison/projection functions,
+    // as_projection, as_comparison and some additional sorter_facade
+    // overloads
+
+    struct wrapper { int value; };
+
+    // Collection to sort
+    std::vector<int> collection(100);
+    std::iota(std::begin(collection), std::end(collection), 0);
+    std::mt19937 engine(std::time(nullptr));
+    std::shuffle(std::begin(collection), std::end(collection), engine);
+    auto vec = collection;
+
+    tricky_function func;
+    comparison_sorter comp_sort;
+    projection_sorter proj_sort;
+
+    SECTION( "comparison_sorter" )
+    {
+        vec = collection;
+        auto res1 = cppsort::sort(comp_sort, vec, func);
+        CHECK( res1 == call::iterable );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        auto res2 = cppsort::sort(comp_sort, std::begin(vec), std::end(vec), func);
+        CHECK( res2 == call::iterator );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        auto res3 = cppsort::sort(comp_sort, vec, cppsort::utility::as_comparison(func));
+        CHECK( res3 == call::iterable );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        auto res4 = cppsort::sort(comp_sort, std::begin(vec), std::end(vec),
+                                  cppsort::utility::as_comparison(func));
+        CHECK( res4 == call::iterator );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        auto res5 = cppsort::sort(comp_sort, vec, cppsort::utility::as_projection(func));
+        CHECK( res5 == call::iterable );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        auto res6 = cppsort::sort(comp_sort, std::begin(vec), std::end(vec),
+                                  cppsort::utility::as_projection(func));
+        CHECK( res6 == call::iterator );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        auto res7 = cppsort::sort(comp_sort, vec, func,
+                                  cppsort::utility::as_projection(func));
+        CHECK( res7 == call::iterable );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        auto res8 = cppsort::sort(comp_sort, std::begin(vec), std::end(vec), func,
+                                  cppsort::utility::as_projection(func));
+        CHECK( res8 == call::iterator );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        auto res9 = cppsort::sort(comp_sort, vec, cppsort::utility::as_comparison(func),
+                                                  cppsort::utility::as_projection(func));
+        CHECK( res9 == call::iterable );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+
+        vec = collection;
+        auto res10 = cppsort::sort(comp_sort, std::begin(vec), std::end(vec),
+                                  cppsort::utility::as_comparison(func),
+                                  cppsort::utility::as_projection(func));
+        CHECK( res10 == call::iterator );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
+    }
+
+    SECTION( "projection_sorter" )
+    {
+        vec = collection;
+        auto res1 = cppsort::sort(proj_sort, vec, cppsort::utility::as_projection(func));
+        CHECK( res1 == call::iterable );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        auto res2 = cppsort::sort(proj_sort, std::begin(vec), std::end(vec),
+                                  cppsort::utility::as_projection(func));
+        CHECK( res2 == call::iterator );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+    }
+}

--- a/testsuite/utility/as_projection_iterable.cpp
+++ b/testsuite/utility/as_projection_iterable.cpp
@@ -103,7 +103,8 @@ namespace
         auto operator()(Iterator first, Iterator last, Projection projection={}) const
             -> call
         {
-            cppsort::sort(first, last, projection);
+            // Use as_projection to make an actual projection-only sorter
+            cppsort::sort(first, last, cppsort::utility::as_projection(projection));
             return call::iterator;
         }
 
@@ -117,7 +118,8 @@ namespace
         auto operator()(Iterable& iterable, Projection projection={}) const
             -> call
         {
-            cppsort::sort(iterable, projection);
+            // Use as_projection to make an actual projection-only sorter
+            cppsort::sort(iterable, cppsort::utility::as_projection(projection));
             return call::iterable;
         }
     };
@@ -205,8 +207,8 @@ TEST_CASE( "sorter_facade with sorters overloaded for iterables and mixed compar
 
         vec = collection;
         auto res10 = cppsort::sort(comp_sort, std::begin(vec), std::end(vec),
-                                  cppsort::utility::as_comparison(func),
-                                  cppsort::utility::as_projection(func));
+                                   cppsort::utility::as_comparison(func),
+                                   cppsort::utility::as_projection(func));
         CHECK( res10 == call::iterator );
         CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
     }
@@ -222,6 +224,16 @@ TEST_CASE( "sorter_facade with sorters overloaded for iterables and mixed compar
         auto res2 = cppsort::sort(proj_sort, std::begin(vec), std::end(vec),
                                   cppsort::utility::as_projection(func));
         CHECK( res2 == call::iterator );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        auto res3 = cppsort::sort(proj_sort, vec, func);
+        CHECK( res3 == call::iterable );
+        CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
+
+        vec = collection;
+        auto res4 = cppsort::sort(proj_sort, std::begin(vec), std::end(vec), func);
+        CHECK( res4 == call::iterator );
         CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
     }
 }


### PR DESCRIPTION
This branch implements the utility functions `as_projection` and `as_comparison` which help disambiguate functions that satisfy both concepts. It also alters `sort`, `stable_sort`, `sorter_facade` and `container_aware_adapter` to ensure that a mixed comparison/projection function is always implicitly considered to be a comparison function a the call would otherwise be ambiguous.