### PR TITLE
Add specific data distributions to tests (fixes #73)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DSANITIZE="${SANITIZE}" .
   - make
   - if [ "${VALGRIND}" = "true" ]; then
-      valgrind --leak-check=full --track-origins=yes testsuite/cpp-sort-testsuite;
+      travis_wait valgrind --leak-check=full --track-origins=yes testsuite/cpp-sort-testsuite;
     else
       testsuite/cpp-sort-testsuite;
     fi

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -34,6 +34,23 @@ set(
 )
 
 set(
+    DISTRIBUTIONS_TESTS
+
+    distributions/all_equal.cpp
+    distributions/alternating.cpp
+    distributions/alternating_16_values.cpp
+    distributions/ascending.cpp
+    distributions/ascending_sawtooth.cpp
+    distributions/descending.cpp
+    distributions/descending_sawtooth.cpp
+    distributions/pipe_organ.cpp
+    distributions/push_front.cpp
+    distributions/push_middle.cpp
+    distributions/shuffled.cpp
+    distributions/shuffled_16_values.cpp
+)
+
+set(
     PROBES_TESTS
 
     probes/dis.cpp
@@ -90,6 +107,7 @@ add_executable(
     sorter_facade_iterable.cpp
     ${ADAPTERS_TESTS}
     ${COMPARATORS_TESTS}
+    ${DISTRIBUTIONS_TESTS}
     ${PROBES_TESTS}
     ${SORTERS_TESTS}
     ${UTILITY_TESTS}

--- a/testsuite/adapters/container_aware_adapter_forward_list.cpp
+++ b/testsuite/adapters/container_aware_adapter_forward_list.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,11 +22,9 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <forward_list>
 #include <functional>
 #include <iterator>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/adapters/container_aware_adapter.h>
@@ -34,6 +32,7 @@
 #include <cpp-sort/sorters/insertion_sorter.h>
 #include <cpp-sort/sorters/merge_sorter.h>
 #include <cpp-sort/sorters/selection_sorter.h>
+#include "../distributions.h"
 
 TEST_CASE( "container_aware_adapter and std::forward_list",
            "[container_aware_adapter]" )
@@ -41,10 +40,9 @@ TEST_CASE( "container_aware_adapter and std::forward_list",
     // Tests for the sorters that have container-aware
     // overloads for std::forward_list
 
-    std::vector<double> vec(187.0);
-    std::iota(std::begin(vec), std::end(vec), -24.0);
-    std::mt19937 engine(std::time(nullptr));
-    std::shuffle(std::begin(vec), std::end(vec), engine);
+    std::vector<double> vec; vec.reserve(187);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(vec), 187, -24.0);
 
     SECTION( "insertion_sorter" )
     {

--- a/testsuite/adapters/container_aware_adapter_list.cpp
+++ b/testsuite/adapters/container_aware_adapter_list.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,11 +22,9 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <functional>
 #include <iterator>
 #include <list>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/adapters/container_aware_adapter.h>
@@ -34,6 +32,7 @@
 #include <cpp-sort/sorters/insertion_sorter.h>
 #include <cpp-sort/sorters/merge_sorter.h>
 #include <cpp-sort/sorters/selection_sorter.h>
+#include "../distributions.h"
 
 TEST_CASE( "container_aware_adapter and std::list",
            "[container_aware_adapter]" )
@@ -41,10 +40,9 @@ TEST_CASE( "container_aware_adapter and std::list",
     // Tests for the sorters that have container-aware
     // overloads for std::list
 
-    std::vector<double> vec(187.0);
-    std::iota(std::begin(vec), std::end(vec), -24.0);
-    std::mt19937 engine(std::time(nullptr));
-    std::shuffle(std::begin(vec), std::end(vec), engine);
+    std::vector<double> vec; vec.reserve(187);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(vec), 187, -24.0);
 
     SECTION( "insertion_sorter" )
     {

--- a/testsuite/adapters/counting_adapter.cpp
+++ b/testsuite/adapters/counting_adapter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2016 Morwenn
+ * Copyright (c) 2015-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@
 #include <ctime>
 #include <iterator>
 #include <list>
+#include <numeric>
 #include <random>
 #include <vector>
 #include <catch.hpp>
@@ -34,14 +35,12 @@
 #include <cpp-sort/sorters/selection_sorter.h>
 #include <cpp-sort/sorters/std_sorter.h>
 #include "../algorithm.h"
+#include "../distributions.h"
 #include "../span.h"
 
 TEST_CASE( "basic counting_adapter tests",
            "[counting_adapter][selection_sorter]" )
 {
-    // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
-
     // Selection sort always makes the same number of comparisons
     // for a given size of arrays, allowing to deterministically
     // check that number of comparisons
@@ -52,10 +51,9 @@ TEST_CASE( "basic counting_adapter tests",
     SECTION( "without projections" )
     {
         // Fill the collection
-        std::vector<int> tmp(65);
-        std::iota(std::begin(tmp), std::end(tmp), 0);
-        std::shuffle(std::begin(tmp), std::end(tmp), engine);
-        std::list<int> collection(std::begin(tmp), std::end(tmp));
+        std::list<int> collection;
+        auto distribution = dist::shuffled{};
+        distribution(std::back_inserter(collection), 65, 0);
 
         // Sort and check it's sorted
         std::size_t res = cppsort::sort(sorter{}, collection);
@@ -66,6 +64,9 @@ TEST_CASE( "basic counting_adapter tests",
     SECTION( "with projections" )
     {
         struct wrapper { int value; };
+
+        // Pseudo-random number engine
+        std::mt19937_64 engine(std::time(nullptr));
 
         // Fill the collection
         std::vector<wrapper> tmp(80);
@@ -84,9 +85,6 @@ TEST_CASE( "basic counting_adapter tests",
 TEST_CASE( "counting_adapter tests with std_sorter",
            "[counting_adapter][std_sorter]" )
 {
-    // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
-
     using sorter = cppsort::counting_adapter<
         cppsort::std_sorter
     >;
@@ -94,9 +92,9 @@ TEST_CASE( "counting_adapter tests with std_sorter",
     SECTION( "without projections" )
     {
         // Fill the collection
-        std::vector<int> collection(65);
-        std::iota(std::begin(collection), std::end(collection), 0);
-        std::shuffle(std::begin(collection), std::end(collection), engine);
+        std::vector<int> collection; collection.reserve(65);
+        auto distribution = dist::shuffled{};
+        distribution(std::back_inserter(collection), 65, 0);
 
         // Sort and check it's sorted
         cppsort::sort(sorter{}, collection);
@@ -107,9 +105,6 @@ TEST_CASE( "counting_adapter tests with std_sorter",
 TEST_CASE( "counting_adapter with span",
            "[counting_adapter][span][selection_sorter]" )
 {
-    // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
-
     using sorter = cppsort::counting_adapter<
         cppsort::selection_sorter
     >;
@@ -117,10 +112,9 @@ TEST_CASE( "counting_adapter with span",
     SECTION( "without projections" )
     {
         // Fill the collection
-        std::vector<int> tmp(65);
-        std::iota(std::begin(tmp), std::end(tmp), 0);
-        std::shuffle(std::begin(tmp), std::end(tmp), engine);
-        std::list<int> collection(std::begin(tmp), std::end(tmp));
+        std::list<int> collection;
+        auto distribution = dist::shuffled{};
+        distribution(std::back_inserter(collection), 65, 0);
 
         // Sort and check it's sorted
         std::size_t res = cppsort::sort(sorter{}, make_span(collection));
@@ -131,6 +125,9 @@ TEST_CASE( "counting_adapter with span",
     SECTION( "with projections" )
     {
         struct wrapper { int value; };
+
+        // Pseudo-random number engine
+        std::mt19937_64 engine(std::time(nullptr));
 
         // Fill the collection
         std::vector<wrapper> tmp(80);

--- a/testsuite/adapters/indirect_adapter.cpp
+++ b/testsuite/adapters/indirect_adapter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,26 +22,26 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <functional>
 #include <iterator>
-#include <numeric>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/adapters/indirect_adapter.h>
 #include <cpp-sort/sort.h>
 #include <cpp-sort/sorters/quick_sorter.h>
 #include "../algorithm.h"
+#include "../distributions.h"
 #include "../span.h"
 
 TEST_CASE( "basic tests with indirect_adapter",
            "[indirect_adapter]" )
 {
-    std::vector<int> collection(221);
-    std::iota(std::begin(collection), std::end(collection), -32);
-    std::mt19937 engine(std::time(nullptr));
-    std::shuffle(std::begin(collection), std::end(collection), engine);
+    std::vector<int> vec; vec.reserve(221);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(vec), 221, -32);
+
+    // Working shuffled copy
+    auto collection = vec;
 
     using sorter = cppsort::indirect_adapter<
         cppsort::quick_sorter
@@ -52,7 +52,7 @@ TEST_CASE( "basic tests with indirect_adapter",
         cppsort::sort(sorter{}, collection, std::greater<>{});
         CHECK( std::is_sorted(std::begin(collection), std::end(collection), std::greater<>{}) );
 
-        std::shuffle(std::begin(collection), std::end(collection), engine);
+        collection = vec;
         cppsort::sort(sorter{}, std::begin(collection), std::end(collection), std::greater<>{});
         CHECK( std::is_sorted(std::begin(collection), std::end(collection), std::greater<>{}) );
     }
@@ -63,7 +63,7 @@ TEST_CASE( "basic tests with indirect_adapter",
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
                                   std::less<>{}, std::negate<>{}) );
 
-        std::shuffle(std::begin(collection), std::end(collection), engine);
+        collection = vec;
         cppsort::sort(sorter{}, std::begin(collection), std::end(collection), std::negate<>{});
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
                                   std::less<>{}, std::negate<>{}) );
@@ -74,7 +74,7 @@ TEST_CASE( "basic tests with indirect_adapter",
         cppsort::sort(sorter{}, collection, std::greater<>{}, std::negate<>{});
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
 
-        std::shuffle(std::begin(collection), std::end(collection), engine);
+        collection = vec;
         cppsort::sort(sorter{}, std::begin(collection), std::end(collection),
                       std::greater<>{}, std::negate<>{});
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
@@ -84,10 +84,9 @@ TEST_CASE( "basic tests with indirect_adapter",
 TEST_CASE( "indirect_adapter with temporary span",
            "[indirect_adapter][span]" )
 {
-    std::vector<int> collection(221);
-    std::iota(std::begin(collection), std::end(collection), -32);
-    std::mt19937 engine(std::time(nullptr));
-    std::shuffle(std::begin(collection), std::end(collection), engine);
+    std::vector<int> collection; collection.reserve(221);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(collection), 221, -32);
 
     using sorter = cppsort::indirect_adapter<
         cppsort::quick_sorter

--- a/testsuite/adapters/indirect_adapter_every_sorter.cpp
+++ b/testsuite/adapters/indirect_adapter_every_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,24 +22,21 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <iterator>
-#include <numeric>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/adapters/indirect_adapter.h>
 #include <cpp-sort/adapters/stable_adapter.h>
 #include <cpp-sort/sort.h>
 #include <cpp-sort/sorters.h>
+#include "../distributions.h"
 
 TEST_CASE( "every sorter with indirect adapter",
            "[indirect_adapter]" )
 {
-    std::vector<double> collection(412);
-    std::iota(std::begin(collection), std::end(collection), -125);
-    std::mt19937 engine(std::time(nullptr));
-    std::shuffle(std::begin(collection), std::end(collection), engine);
+    std::vector<double> collection; collection.reserve(412);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(collection), 412, -125.0);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/adapters/self_sort_adapter_no_compare.cpp
+++ b/testsuite/adapters/self_sort_adapter_no_compare.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2016 Morwenn
+ * Copyright (c) 2015-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,16 +22,15 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <iterator>
 #include <list>
-#include <random>
 #include <utility>
 #include <catch.hpp>
 #include <cpp-sort/adapters/self_sort_adapter.h>
 #include <cpp-sort/sorters/verge_sorter.h>
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sort.h>
+#include "../distributions.h"
 
 namespace
 {
@@ -85,11 +84,9 @@ namespace
 TEST_CASE( "self-sortable object without comparison",
            "[self_sort_adapter][no_compare]" )
 {
-    // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
-
     // Collection to sort
-    non_comparison_self_sortable collection(80);
+    auto size = 80;
+    non_comparison_self_sortable collection(size);
 
     SECTION( "without a comparator" )
     {
@@ -101,9 +98,9 @@ TEST_CASE( "self-sortable object without comparison",
         >;
 
         // Fill the collection
-        std::vector<int> tmp(std::distance(std::begin(collection), std::end(collection)));
-        std::iota(std::begin(tmp), std::end(tmp), 0);
-        std::shuffle(std::begin(tmp), std::end(tmp), engine);
+        std::vector<int> tmp; tmp.reserve(size);
+        auto distribution = dist::shuffled{};
+        distribution(std::back_inserter(tmp), size, 0);
         std::copy(std::begin(tmp), std::end(tmp), std::begin(collection));
 
         // Sort and check it's sorted
@@ -122,9 +119,9 @@ TEST_CASE( "self-sortable object without comparison",
         >;
 
         // Fill the collection
-        std::vector<int> tmp(std::distance(std::begin(collection), std::end(collection)));
-        std::iota(std::begin(tmp), std::end(tmp), 0);
-        std::shuffle(std::begin(tmp), std::end(tmp), engine);
+        std::vector<int> tmp; tmp.reserve(size);
+        auto distribution = dist::shuffled{};
+        distribution(std::back_inserter(tmp), size, 0);
         std::copy(std::begin(tmp), std::end(tmp), std::begin(collection));
 
         // Sort and check it's sorted

--- a/testsuite/distributions.h
+++ b/testsuite/distributions.h
@@ -1,0 +1,237 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_TESTSUITE_DISTRIBUTIONS_H_
+#define CPPSORT_TESTSUITE_DISTRIBUTIONS_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <algorithm>
+#include <ctime>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <vector>
+#include <cpp-sort/utility/bitops.h>
+
+namespace dist
+{
+    template<typename Derived>
+    struct distribution
+    {
+        template<typename OutputIterator>
+        using fptr_t = void(*)(OutputIterator, std::size_t);
+
+        template<typename OutputIterator>
+        operator fptr_t<OutputIterator>() const
+        {
+            return [](OutputIterator out, std::size_t size) {
+                return Derived{}(out, size);
+            };
+        }
+    };
+
+    struct shuffled:
+        distribution<shuffled>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            // Pseudo-random number generator
+            thread_local std::mt19937_64 engine(std::time(nullptr));
+
+            std::vector<int> vec;
+            for (std::size_t i = 0 ; i < size ; ++i) {
+                vec.emplace_back(i);
+            }
+            std::shuffle(std::begin(vec), std::end(vec), engine);
+            std::move(std::begin(vec), std::end(vec), out);
+        }
+    };
+
+    struct shuffled_16_values:
+        distribution<shuffled_16_values>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            // Pseudo-random number generator
+            thread_local std::mt19937_64 engine(std::time(nullptr));
+
+            std::vector<int> vec;
+            for (std::size_t i = 0 ; i < size ; ++i) {
+                vec.emplace_back(i % 16);
+            }
+            std::shuffle(std::begin(vec), std::end(vec), engine);
+            std::move(std::begin(vec), std::end(vec), out);
+        }
+    };
+
+    struct all_equal:
+        distribution<all_equal>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            for (std::size_t i = 0 ; i < size ; ++i) {
+                *out++ = 0;
+            }
+        }
+    };
+
+    struct ascending:
+        distribution<ascending>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            for (std::size_t i = 0 ; i < size ; ++i) {
+                *out++ = i;
+            }
+        }
+    };
+
+    struct descending:
+        distribution<descending>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            while (size--) {
+                *out++ = size;
+            }
+        }
+    };
+
+    struct pipe_organ:
+        distribution<pipe_organ>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            for (std::size_t i = 0 ; i < size / 2 ; ++i) {
+                *out++ = i;
+            }
+            for (std::size_t i = size / 2 ; i < size ; ++i) {
+                *out++ = size - i;
+            }
+        }
+    };
+
+    struct push_front:
+        distribution<push_front>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            if (size > 0) {
+                for (std::size_t i = 0 ; i < size - 1 ; ++i) {
+                    *out++ = i;
+                }
+                *out = 0;
+            }
+        }
+    };
+
+    struct push_middle:
+        distribution<push_middle>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            if (size > 0) {
+                for (std::size_t i = 0 ; i < size ; ++i) {
+                    if (i != size / 2) {
+                        *out++ = i;
+                    }
+                }
+                *out = size / 2;
+            }
+        }
+    };
+
+    struct ascending_sawtooth:
+        distribution<ascending_sawtooth>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            std::size_t limit = size / cppsort::utility::log2(size) * 1.1;
+            for (std::size_t i = 0 ; i < size ; ++i) {
+                *out++ = i % limit;
+            }
+        }
+    };
+
+    struct descending_sawtooth:
+        distribution<descending_sawtooth>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            std::size_t limit = size / cppsort::utility::log2(size) * 1.1;
+            while (size--) {
+                *out++ = size % limit;
+            }
+        }
+    };
+
+    struct alternating:
+        distribution<alternating>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            for (std::size_t i = 0 ; i < size ; ++i) {
+                *out++ = (i % 2) ? i : -i;
+            }
+        }
+    };
+
+    struct alternating_16_values:
+        distribution<alternating_16_values>
+    {
+        template<typename OutputIterator>
+        auto operator()(OutputIterator out, std::size_t size) const
+            -> void
+        {
+            for (std::size_t i = 0 ; i < size ; ++i) {
+                *out++ = (i % 2) ? i % 16 : -(i % 16);
+            }
+        }
+    };
+}
+
+#endif // CPPSORT_TESTSUITE_DISTRIBUTIONS_H_

--- a/testsuite/distributions.h
+++ b/testsuite/distributions.h
@@ -28,12 +28,17 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <algorithm>
-#include <ctime>
+#include <cstddef>
 #include <iterator>
 #include <numeric>
 #include <random>
 #include <vector>
 #include <cpp-sort/utility/bitops.h>
+
+#ifdef __MINGW32__
+    // Poor seed for the pseudo-random number generation
+#   include <ctime>
+#endif
 
 namespace dist
 {
@@ -55,15 +60,22 @@ namespace dist
     struct shuffled:
         distribution<shuffled>
     {
-        template<typename OutputIterator>
-        auto operator()(OutputIterator out, std::size_t size) const
+        template<typename OutputIterator, typename T=long long int>
+        auto operator()(OutputIterator out, long long int size, T start=T(0)) const
             -> void
         {
             // Pseudo-random number generator
-            thread_local std::mt19937_64 engine(std::time(nullptr));
+#ifdef __MINGW32__
+            thread_local std::mt19937 engine(std::time(nullptr));
+#else
+            thread_local std::mt19937 engine(std::random_device{}());
+#endif
 
-            std::vector<int> vec;
-            for (std::size_t i = 0 ; i < size ; ++i) {
+            std::vector<T> vec;
+            vec.reserve(size);
+
+            T end = start + size;
+            for (auto i = start ; i < end ; ++i) {
                 vec.emplace_back(i);
             }
             std::shuffle(std::begin(vec), std::end(vec), engine);
@@ -79,9 +91,15 @@ namespace dist
             -> void
         {
             // Pseudo-random number generator
-            thread_local std::mt19937_64 engine(std::time(nullptr));
+#ifdef __MINGW32__
+            thread_local std::mt19937 engine(std::time(nullptr));
+#else
+            thread_local std::mt19937 engine(std::random_device{}());
+#endif
 
             std::vector<int> vec;
+            vec.reserve(size);
+
             for (std::size_t i = 0 ; i < size ; ++i) {
                 vec.emplace_back(i % 16);
             }

--- a/testsuite/distributions/all_equal.cpp
+++ b/testsuite/distributions/all_equal.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with all_equal distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::all_equal{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/all_equal.cpp
+++ b/testsuite/distributions/all_equal.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with all_equal distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::all_equal{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/all_equal.cpp
+++ b/testsuite/distributions/all_equal.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with all_equal distribution", "[distributions]" )
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::all_equal{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/distributions/all_equal.cpp
+++ b/testsuite/distributions/all_equal.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with all_equal distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::all_equal{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/alternating.cpp
+++ b/testsuite/distributions/alternating.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with alternating distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::alternating{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/alternating.cpp
+++ b/testsuite/distributions/alternating.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with alternating distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::alternating{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/alternating.cpp
+++ b/testsuite/distributions/alternating.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with alternating distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::alternating{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/alternating.cpp
+++ b/testsuite/distributions/alternating.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with alternating distribution", "[distributions]" )
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::alternating{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/distributions/alternating_16_values.cpp
+++ b/testsuite/distributions/alternating_16_values.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with alternating_16_values distribution", "[distribution
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::alternating_16_values{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/distributions/alternating_16_values.cpp
+++ b/testsuite/distributions/alternating_16_values.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with alternating_16_values distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::alternating_16_values{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/alternating_16_values.cpp
+++ b/testsuite/distributions/alternating_16_values.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with alternating_16_values distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::alternating_16_values{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/alternating_16_values.cpp
+++ b/testsuite/distributions/alternating_16_values.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with alternating_16_values distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::alternating_16_values{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/ascending.cpp
+++ b/testsuite/distributions/ascending.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with ascending distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::ascending{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/ascending.cpp
+++ b/testsuite/distributions/ascending.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with ascending distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::ascending{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/ascending.cpp
+++ b/testsuite/distributions/ascending.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with ascending distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::ascending{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/ascending_sawtooth.cpp
+++ b/testsuite/distributions/ascending_sawtooth.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with ascending_sawtooth distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::ascending_sawtooth{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/ascending_sawtooth.cpp
+++ b/testsuite/distributions/ascending_sawtooth.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with ascending_sawtooth distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::ascending_sawtooth{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/ascending_sawtooth.cpp
+++ b/testsuite/distributions/ascending_sawtooth.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with ascending_sawtooth distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::ascending_sawtooth{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/ascending_sawtooth.cpp
+++ b/testsuite/distributions/ascending_sawtooth.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with ascending_sawtooth distribution", "[distributions]"
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::ascending_sawtooth{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/distributions/descending.cpp
+++ b/testsuite/distributions/descending.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with descending distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::descending{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/descending.cpp
+++ b/testsuite/distributions/descending.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with descending distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::descending{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/descending.cpp
+++ b/testsuite/distributions/descending.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with descending distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::descending{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/descending.cpp
+++ b/testsuite/distributions/descending.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with descending distribution", "[distributions]" )
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::descending{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/distributions/descending_sawtooth.cpp
+++ b/testsuite/distributions/descending_sawtooth.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with descending_sawtooth distribution", "[distributions]
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::descending_sawtooth{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/distributions/descending_sawtooth.cpp
+++ b/testsuite/distributions/descending_sawtooth.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with descending_sawtooth distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::descending_sawtooth{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/descending_sawtooth.cpp
+++ b/testsuite/distributions/descending_sawtooth.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with descending_sawtooth distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::descending_sawtooth{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/descending_sawtooth.cpp
+++ b/testsuite/distributions/descending_sawtooth.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with descending_sawtooth distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::descending_sawtooth{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/pipe_organ.cpp
+++ b/testsuite/distributions/pipe_organ.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with pipe_organ distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::pipe_organ{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/pipe_organ.cpp
+++ b/testsuite/distributions/pipe_organ.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with pipe_organ distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::pipe_organ{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/pipe_organ.cpp
+++ b/testsuite/distributions/pipe_organ.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with pipe_organ distribution", "[distributions]" )
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::pipe_organ{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/distributions/pipe_organ.cpp
+++ b/testsuite/distributions/pipe_organ.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with pipe_organ distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::pipe_organ{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/push_front.cpp
+++ b/testsuite/distributions/push_front.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with push_front distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::push_front{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/push_front.cpp
+++ b/testsuite/distributions/push_front.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with push_front distribution", "[distributions]" )
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::push_front{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/distributions/push_front.cpp
+++ b/testsuite/distributions/push_front.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with push_front distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::push_front{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/push_front.cpp
+++ b/testsuite/distributions/push_front.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with push_front distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::push_front{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/push_middle.cpp
+++ b/testsuite/distributions/push_middle.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with push_middle distribution", "[distributions]" )
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::push_middle{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/distributions/push_middle.cpp
+++ b/testsuite/distributions/push_middle.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with push_middle distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::push_middle{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/push_middle.cpp
+++ b/testsuite/distributions/push_middle.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with push_middle distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::push_middle{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/push_middle.cpp
+++ b/testsuite/distributions/push_middle.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with push_middle distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::push_middle{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/shuffled.cpp
+++ b/testsuite/distributions/shuffled.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with shuffled distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/shuffled.cpp
+++ b/testsuite/distributions/shuffled.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with shuffled distribution", "[distributions]" )
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::shuffled{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/distributions/shuffled.cpp
+++ b/testsuite/distributions/shuffled.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with shuffled distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::shuffled{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/shuffled.cpp
+++ b/testsuite/distributions/shuffled.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with shuffled distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::shuffled{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/shuffled_16_values.cpp
+++ b/testsuite/distributions/shuffled_16_values.cpp
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <catch.hpp>
+#include <cpp-sort/sort.h>
+#include <cpp-sort/sorters.h>
+#include <cpp-sort/utility/buffer.h>
+#include <cpp-sort/utility/functional.h>
+#include "../distributions.h"
+
+TEST_CASE( "test sorter with shuffled_16_values distribution", "[distributions]" )
+{
+    std::vector<int> collection(100'000);
+    auto distribution = dist::shuffled_16_values{};
+    distribution(std::back_inserter(collection), collection.size());
+
+    SECTION( "block_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(block_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(block_sorter<utility::dynamic_buffer<utility::sqrt>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "grail_sorter" )
+    {
+        using namespace cppsort;
+
+        // Fixed buffer
+        cppsort::sort(grail_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        // Dynamic buffer
+        cppsort::sort(grail_sorter<utility::dynamic_buffer<utility::half>>{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "heap_sorter" )
+    {
+        cppsort::sort(cppsort::heap_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "merge_sorter" )
+    {
+        cppsort::sort(cppsort::merge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "pdq_sorter" )
+    {
+        cppsort::sort(cppsort::pdq_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "poplar_sorter" )
+    {
+        cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_sorter" )
+    {
+        cppsort::sort(cppsort::quick_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "smooth_sorter" )
+    {
+        cppsort::sort(cppsort::smooth_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "spread_sorter" )
+    {
+        cppsort::sort(cppsort::spread_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "std_sorter" )
+    {
+        cppsort::sort(cppsort::std_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "tim_sorter" )
+    {
+        cppsort::sort(cppsort::tim_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "verge_sorter" )
+    {
+        cppsort::sort(cppsort::verge_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+}

--- a/testsuite/distributions/shuffled_16_values.cpp
+++ b/testsuite/distributions/shuffled_16_values.cpp
@@ -33,7 +33,8 @@
 
 TEST_CASE( "test sorter with shuffled_16_values distribution", "[distributions]" )
 {
-    std::vector<int> collection(10'000);
+    std::vector<int> collection;
+    collection.reserve(10'000);
     auto distribution = dist::shuffled_16_values{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/shuffled_16_values.cpp
+++ b/testsuite/distributions/shuffled_16_values.cpp
@@ -33,7 +33,7 @@
 
 TEST_CASE( "test sorter with shuffled_16_values distribution", "[distributions]" )
 {
-    std::vector<int> collection(100'000);
+    std::vector<int> collection(10'000);
     auto distribution = dist::shuffled_16_values{};
     distribution(std::back_inserter(collection), collection.size());
 

--- a/testsuite/distributions/shuffled_16_values.cpp
+++ b/testsuite/distributions/shuffled_16_values.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "test sorter with shuffled_16_values distribution", "[distributions]"
     std::vector<int> collection;
     collection.reserve(10'000);
     auto distribution = dist::shuffled_16_values{};
-    distribution(std::back_inserter(collection), collection.size());
+    distribution(std::back_inserter(collection), 10'000);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/every_instantiated_sorter.cpp
+++ b/testsuite/every_instantiated_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,13 +22,11 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <iterator>
-#include <numeric>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sorters.h>
+#include "distributions.h"
 
 TEST_CASE( "test every instantiated sorter", "[sorters]" )
 {
@@ -40,10 +38,9 @@ TEST_CASE( "test every instantiated sorter", "[sorters]" )
     // Only default_sorter doesn't have a standard instance
     // since it is already used by default by cppsort::sort
 
-    std::vector<long long int> collection(35);
-    std::iota(std::begin(collection), std::end(collection), -47);
-    std::mt19937 engine(std::time(nullptr));
-    std::shuffle(std::begin(collection), std::end(collection), engine);
+    std::vector<long long int> collection; collection.reserve(35);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(collection), 35, -47);
 
     SECTION( "block_sort" )
     {

--- a/testsuite/every_sorter.cpp
+++ b/testsuite/every_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,16 +22,14 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <iterator>
-#include <numeric>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sort.h>
 #include <cpp-sort/sorters.h>
 #include <cpp-sort/utility/buffer.h>
 #include <cpp-sort/utility/functional.h>
+#include "distributions.h"
 
 TEST_CASE( "test every sorter", "[sorters]" )
 {
@@ -40,10 +38,9 @@ TEST_CASE( "test every sorter", "[sorters]" )
     // already tested in-depth somewhere else and needs specific
     // tests, so it's not included here.
 
-    std::vector<int> collection(491);
-    std::iota(std::begin(collection), std::end(collection), -125);
-    std::mt19937 engine(std::time(nullptr));
-    std::shuffle(std::begin(collection), std::end(collection), engine);
+    std::vector<int> collection; collection.reserve(491);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(collection), 491, -125);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/every_sorter_span.cpp
+++ b/testsuite/every_sorter_span.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,30 +22,26 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <iterator>
-#include <numeric>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sort.h>
 #include <cpp-sort/sorters.h>
 #include <cpp-sort/utility/buffer.h>
 #include <cpp-sort/utility/functional.h>
+#include "distributions.h"
 #include "span.h"
 
 TEST_CASE( "test every sorter with temporary span",
            "[sorters][span]" )
 {
     // General test to make sure that every sorter compiles fine
-    // and is able to sort a vector of numbers. spread_sorter is
-    // already tested in-depth somewhere else and needs specific
-    // tests, so it's not included here.
+    // and is able to sort a temporary span referencing a vector
+    // of numbers
 
-    std::vector<long int> collection(491);
-    std::iota(std::begin(collection), std::end(collection), -125);
-    std::mt19937 engine(std::time(nullptr));
-    std::shuffle(std::begin(collection), std::end(collection), engine);
+    std::vector<long int> collection; collection.reserve(491);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(collection), 491, -125);
 
     SECTION( "block_sorter" )
     {

--- a/testsuite/probes/relations.cpp
+++ b/testsuite/probes/relations.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,21 +21,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <algorithm>
-#include <ctime>
 #include <iterator>
-#include <numeric>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/probes.h>
+#include "../distributions.h"
 
 TEST_CASE( "relations between measures of presortedness", "[probe]" )
 {
-    std::vector<int> sequence(100);
-    std::iota(std::begin(sequence), std::end(sequence), 0);
-    std::mt19937 engine(std::time(nullptr));
-    std::shuffle(std::begin(sequence), std::end(sequence), engine);
+    std::vector<int> sequence; sequence.reserve(100);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(sequence), 100, 0);
 
     // The computer science literature lists a number of
     // relations between the results of different measures

--- a/testsuite/sorters/counting_sorter.cpp
+++ b/testsuite/sorters/counting_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,57 +22,50 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <forward_list>
 #include <iterator>
 #include <list>
-#include <numeric>
-#include <random>
-#include <string>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sorters/counting_sorter.h>
 #include <cpp-sort/sort.h>
+#include "../distributions.h"
 
 TEST_CASE( "counting_sorter tests", "[counting_sorter]" )
 {
-    // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    // Distribution used to generate the data to sort
+    auto distribution = dist::shuffled{};
+    // Size of the collections to sort
+    auto size = 100'000;
 
     SECTION( "sort with int iterable" )
     {
-        std::vector<int> vec(100'000);
-        std::iota(std::begin(vec), std::end(vec), -1568);
-        std::shuffle(std::begin(vec), std::end(vec), engine);
+        std::vector<int> vec; vec.reserve(size);
+        distribution(std::back_inserter(vec), size, -1568);
         cppsort::sort(cppsort::counting_sorter{}, vec);
         CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
     }
 
     SECTION( "sort with unsigned int iterators" )
     {
-        std::vector<unsigned> vec(100'000);
-        std::iota(std::begin(vec), std::end(vec), 0u);
-        std::shuffle(std::begin(vec), std::end(vec), engine);
-        std::list<unsigned> li(std::begin(vec), std::end(vec));
+        std::list<unsigned> li;;
+        distribution(std::back_inserter(li), size, 0u);
         cppsort::sort(cppsort::counting_sorter{}, std::begin(li), std::end(li));
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
     }
 
     SECTION( "reverse sort with long long iterable" )
     {
-        std::vector<long long> vec(100'000);
-        std::iota(std::begin(vec), std::end(vec), 1568);
-        std::shuffle(std::begin(vec), std::end(vec), engine);
+        std::vector<long long> vec; vec.reserve(size);
+        distribution(std::back_inserter(vec), size, 1568);
         cppsort::sort(cppsort::counting_sorter{}, vec);
         CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
     }
 
     SECTION( "reverse sort with unsigned long long iterators" )
     {
-        std::vector<unsigned long long> vec(100'000);
-        std::iota(std::begin(vec), std::end(vec), 0u);
-        std::shuffle(std::begin(vec), std::end(vec), engine);
-        std::forward_list<unsigned long long> li(std::begin(vec), std::end(vec));
+        std::forward_list<unsigned long long> li;
+        distribution(std::front_inserter(li), size, 0ULL);
         cppsort::sort(cppsort::counting_sorter{}, std::begin(li), std::end(li));
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
     }

--- a/testsuite/sorters/default_sorter.cpp
+++ b/testsuite/sorters/default_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,57 +22,49 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <forward_list>
 #include <functional>
 #include <iterator>
 #include <list>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sorters/default_sorter.h>
 #include <cpp-sort/sort.h>
+#include "../distributions.h"
 
 TEST_CASE( "default sorter tests", "[default_sorter]" )
 {
-    // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
-
     // Collection to sort
-    std::vector<int> vec(80);
-    std::iota(std::begin(vec), std::end(vec), 0);
+    std::vector<int> vec; vec.reserve(80);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(vec), 80, 0);
 
     SECTION( "sort with random-access iterable" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         cppsort::sort(vec);
         CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
     }
 
     SECTION( "sort with random-access iterable and compare" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         cppsort::sort(vec, std::greater<>{});
         CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
     }
 
     SECTION( "sort with random-access iterators" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         cppsort::sort(std::begin(vec), std::end(vec));
         CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
     }
 
     SECTION( "sort with random-access iterators and compare" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         cppsort::sort(std::begin(vec), std::end(vec), std::greater<>{});
         CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
     }
 
     SECTION( "sort with bidirectional iterators" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::list<int> li(std::begin(vec), std::end(vec));
         cppsort::sort(std::begin(li), std::end(li));
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
@@ -80,7 +72,6 @@ TEST_CASE( "default sorter tests", "[default_sorter]" )
 
     SECTION( "sort with bidirectional iterators and compare" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::list<int> li(std::begin(vec), std::end(vec));
         cppsort::sort(std::begin(li), std::end(li), std::greater<>{});
         CHECK( std::is_sorted(std::begin(li), std::end(li), std::greater<>{}) );
@@ -88,7 +79,6 @@ TEST_CASE( "default sorter tests", "[default_sorter]" )
 
     SECTION( "sort with forward iterators" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::forward_list<int> li(std::begin(vec), std::end(vec));
         cppsort::sort(std::begin(li), std::end(li));
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
@@ -96,7 +86,6 @@ TEST_CASE( "default sorter tests", "[default_sorter]" )
 
     SECTION( "sort with forward iterators and compare" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::forward_list<int> li(std::begin(vec), std::end(vec));
         cppsort::sort(std::begin(li), std::end(li), std::greater<>{});
         CHECK( std::is_sorted(std::begin(li), std::end(li), std::greater<>{}) );
@@ -104,7 +93,6 @@ TEST_CASE( "default sorter tests", "[default_sorter]" )
 
     SECTION( "sort with self-sortable iterable" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::list<int> li(std::begin(vec), std::end(vec));
         cppsort::sort(li);
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
@@ -112,7 +100,6 @@ TEST_CASE( "default sorter tests", "[default_sorter]" )
 
     SECTION( "sort with self-sortable iterable and compare" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::forward_list<int> li(std::begin(vec), std::end(vec));
         cppsort::sort(li, std::greater<>{});
         CHECK( std::is_sorted(std::begin(li), std::end(li), std::greater<>{}) );

--- a/testsuite/sorters/default_sorter_fptr.cpp
+++ b/testsuite/sorters/default_sorter_fptr.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,25 +22,22 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <forward_list>
 #include <functional>
 #include <iterator>
 #include <list>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sorters/default_sorter.h>
+#include "../distributions.h"
 
 TEST_CASE( "default sorter function pointer tests",
            "[default_sorter][function_pointer]" )
 {
-    // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
-
     // Collection to sort
-    std::vector<int> vec(80);
-    std::iota(std::begin(vec), std::end(vec), 0);
+    std::vector<int> vec; vec.reserve(80);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(vec), 80, 0);
 
     // Projection to sort in descending order
     auto projection = [](int n) { return -n; };
@@ -49,7 +46,6 @@ TEST_CASE( "default sorter function pointer tests",
     {
         void(*sorter)(std::vector<int>&) = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         sorter(vec);
         CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
     }
@@ -58,7 +54,6 @@ TEST_CASE( "default sorter function pointer tests",
     {
         void(*sorter)(std::vector<int>&, std::greater<>) = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         sorter(vec, std::greater<>{});
         CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
     }
@@ -67,7 +62,6 @@ TEST_CASE( "default sorter function pointer tests",
     {
         void(*sorter)(std::vector<int>&, decltype(projection)) = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         sorter(vec, projection);
         CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
     }
@@ -79,7 +73,6 @@ TEST_CASE( "default sorter function pointer tests",
                       decltype(projection))
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         sorter(vec, std::greater<>{}, projection);
         CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
     }
@@ -90,7 +83,6 @@ TEST_CASE( "default sorter function pointer tests",
                       std::vector<int>::iterator)
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         sorter(std::begin(vec), std::end(vec));
         CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
     }
@@ -102,7 +94,6 @@ TEST_CASE( "default sorter function pointer tests",
                       std::greater<>)
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         sorter(std::begin(vec), std::end(vec), std::greater<>{});
         CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
     }
@@ -114,7 +105,6 @@ TEST_CASE( "default sorter function pointer tests",
                       decltype(projection))
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         sorter(std::begin(vec), std::end(vec), projection);
         CHECK( std::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}) );
     }
@@ -127,7 +117,6 @@ TEST_CASE( "default sorter function pointer tests",
                       decltype(projection))
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         sorter(std::begin(vec), std::end(vec), std::greater<>{}, projection);
         CHECK( std::is_sorted(std::begin(vec), std::end(vec)) );
     }
@@ -138,7 +127,6 @@ TEST_CASE( "default sorter function pointer tests",
                       std::list<int>::iterator)
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::list<int> li(std::begin(vec), std::end(vec));
         sorter(std::begin(li), std::end(li));
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
@@ -151,7 +139,6 @@ TEST_CASE( "default sorter function pointer tests",
                       std::greater<>)
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::list<int> li(std::begin(vec), std::end(vec));
         sorter(std::begin(li), std::end(li), std::greater<>{});
         CHECK( std::is_sorted(std::begin(li), std::end(li), std::greater<>{}) );
@@ -164,7 +151,6 @@ TEST_CASE( "default sorter function pointer tests",
                       decltype(projection))
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::list<int> li(std::begin(vec), std::end(vec));
         sorter(std::begin(li), std::end(li), projection);
         CHECK( std::is_sorted(std::begin(li), std::end(li), std::greater<>{}) );
@@ -178,7 +164,6 @@ TEST_CASE( "default sorter function pointer tests",
                       decltype(projection))
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::list<int> li(std::begin(vec), std::end(vec));
         sorter(std::begin(li), std::end(li), std::greater<>{}, projection);
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
@@ -190,7 +175,6 @@ TEST_CASE( "default sorter function pointer tests",
                       std::forward_list<int>::iterator)
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::forward_list<int> li(std::begin(vec), std::end(vec));
         sorter(std::begin(li), std::end(li));
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
@@ -203,7 +187,6 @@ TEST_CASE( "default sorter function pointer tests",
                       std::greater<>)
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::forward_list<int> li(std::begin(vec), std::end(vec));
         sorter(std::begin(li), std::end(li), std::greater<>{});
         CHECK( std::is_sorted(std::begin(li), std::end(li), std::greater<>{}) );
@@ -216,7 +199,6 @@ TEST_CASE( "default sorter function pointer tests",
                       decltype(projection))
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::forward_list<int> li(std::begin(vec), std::end(vec));
         sorter(std::begin(li), std::end(li), projection);
         CHECK( std::is_sorted(std::begin(li), std::end(li), std::greater<>{}) );
@@ -230,7 +212,6 @@ TEST_CASE( "default sorter function pointer tests",
                       decltype(projection))
             = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::forward_list<int> li(std::begin(vec), std::end(vec));
         sorter(std::begin(li), std::end(li), std::greater<>{}, projection);
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
@@ -240,7 +221,6 @@ TEST_CASE( "default sorter function pointer tests",
     {
         void(*sorter)(std::list<int>&) = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::list<int> li(std::begin(vec), std::end(vec));
         sorter(li);
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
@@ -250,7 +230,6 @@ TEST_CASE( "default sorter function pointer tests",
     {
         void(*sorter)(std::forward_list<int>&, std::greater<>) = cppsort::default_sorter();
 
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::forward_list<int> li(std::begin(vec), std::end(vec));
         sorter(li, std::greater<>{});
         CHECK( std::is_sorted(std::begin(li), std::end(li), std::greater<>{}) );

--- a/testsuite/sorters/default_sorter_projection.cpp
+++ b/testsuite/sorters/default_sorter_projection.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Morwenn
+ * Copyright (c) 2015-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -47,38 +47,34 @@ TEST_CASE( "default sorter tests with projections",
     // Collection to sort
     std::vector<wrapper> vec(80);
     helpers::iota(std::begin(vec), std::end(vec), 0, &wrapper::value);
+    std::shuffle(std::begin(vec), std::end(vec), engine);
 
     SECTION( "sort with random-access iterable" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         cppsort::sort(vec, &wrapper::value);
         CHECK( helpers::is_sorted(std::begin(vec), std::end(vec), std::less<>{}, &wrapper::value) );
     }
 
     SECTION( "sort with random-access iterable and compare" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         cppsort::sort(vec, std::greater<>{}, &wrapper::value);
         CHECK( helpers::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}, &wrapper::value) );
     }
 
     SECTION( "sort with random-access iterators" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         cppsort::sort(std::begin(vec), std::end(vec), &wrapper::value);
         CHECK( helpers::is_sorted(std::begin(vec), std::end(vec), std::less<>{}, &wrapper::value) );
     }
 
     SECTION( "sort with random-access iterators and compare" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         cppsort::sort(std::begin(vec), std::end(vec), std::greater<>{}, &wrapper::value);
         CHECK( helpers::is_sorted(std::begin(vec), std::end(vec), std::greater<>{}, &wrapper::value) );
     }
 
     SECTION( "sort with bidirectional iterators" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::list<wrapper> li(std::begin(vec), std::end(vec));
         cppsort::sort(std::begin(li), std::end(li), &wrapper::value);
         CHECK( helpers::is_sorted(std::begin(li), std::end(li), std::less<>{}, &wrapper::value) );
@@ -86,7 +82,6 @@ TEST_CASE( "default sorter tests with projections",
 
     SECTION( "sort with bidirectional iterators and compare" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::list<wrapper> li(std::begin(vec), std::end(vec));
         cppsort::sort(std::begin(li), std::end(li), std::greater<>{}, &wrapper::value);
         CHECK( helpers::is_sorted(std::begin(li), std::end(li), std::greater<>{}, &wrapper::value) );
@@ -94,7 +89,6 @@ TEST_CASE( "default sorter tests with projections",
 
     SECTION( "sort with forward iterators" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::forward_list<wrapper> li(std::begin(vec), std::end(vec));
         cppsort::sort(std::begin(li), std::end(li), &wrapper::value);
         CHECK( helpers::is_sorted(std::begin(li), std::end(li), std::less<>{}, &wrapper::value) );
@@ -102,7 +96,6 @@ TEST_CASE( "default sorter tests with projections",
 
     SECTION( "sort with forward iterators and compare" )
     {
-        std::shuffle(std::begin(vec), std::end(vec), engine);
         std::forward_list<wrapper> li(std::begin(vec), std::end(vec));
         cppsort::sort(std::begin(li), std::end(li), std::greater<>{}, &wrapper::value);
         CHECK( helpers::is_sorted(std::begin(li), std::end(li), std::greater<>{}, &wrapper::value) );

--- a/testsuite/sorters/merge_sorter.cpp
+++ b/testsuite/sorters/merge_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2016 Morwenn
+ * Copyright (c) 2015-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +22,22 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <forward_list>
 #include <functional>
 #include <iterator>
 #include <list>
-#include <numeric>
-#include <random>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sorters/merge_sorter.h>
 #include <cpp-sort/sort.h>
+#include "../distributions.h"
 
 TEST_CASE( "merge_sorter tests", "[merge_sorter]" )
 {
-    // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
-
     // Collection to sort
-    std::vector<int> vec(80);
-    std::iota(std::begin(vec), std::end(vec), 0);
-    std::shuffle(std::begin(vec), std::end(vec), engine);
+    std::vector<int> vec; vec.reserve(80);
+    auto distribution = dist::shuffled{};
+    distribution(std::back_inserter(vec), 80, 0);
 
     SECTION( "sort with random-access iterable" )
     {


### PR DESCRIPTION
Test sorters with specific data distributions, currently the ones used in the benchmarks, even though more specific patterns will probably be needed in the future (I'm looking at you, vergesort).

O(n²) sorts are left out of the tests (except quicksort) because the collections with specific distributions have 10000 elements, so these quadratic sorts would be way too slow. `counting_sort` doesn't appear in these tests either because it obviously doesn't care about patterns.