### PR TITLE
Add branchless traits to the library (fixes #101)

### DIFF
--- a/include/cpp-sort/comparators/partial_greater.h
+++ b/include/cpp-sort/comparators/partial_greater.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@
 #include <type_traits>
 #include <utility>
 #include <cpp-sort/comparators/weak_greater.h>
+#include <cpp-sort/utility/branchless_traits.h>
 #include <cpp-sort/utility/static_const.h>
 
 namespace cppsort
@@ -77,6 +78,16 @@ namespace cppsort
         constexpr auto&& partial_greater = utility::static_const<
             detail::partial_greater_fn
         >::value;
+    }
+
+    // Branchless traits
+
+    namespace utility
+    {
+        template<typename T>
+        struct is_probably_branchless_comparison<decltype(partial_greater), T>:
+            std::is_arithmetic<T>
+        {};
     }
 }
 

--- a/include/cpp-sort/comparators/partial_less.h
+++ b/include/cpp-sort/comparators/partial_less.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@
 #include <type_traits>
 #include <utility>
 #include <cpp-sort/comparators/weak_less.h>
+#include <cpp-sort/utility/branchless_traits.h>
 #include <cpp-sort/utility/static_const.h>
 
 namespace cppsort
@@ -77,6 +78,16 @@ namespace cppsort
         constexpr auto&& partial_less = utility::static_const<
             detail::partial_less_fn
         >::value;
+    }
+
+    // Branchless traits
+
+    namespace utility
+    {
+        template<typename T>
+        struct is_probably_branchless_comparison<decltype(partial_less), T>:
+            std::is_arithmetic<T>
+        {};
     }
 }
 

--- a/include/cpp-sort/comparators/total_greater.h
+++ b/include/cpp-sort/comparators/total_greater.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <type_traits>
 #include <utility>
+#include <cpp-sort/utility/branchless_traits.h>
 #include <cpp-sort/utility/static_const.h>
 #include "../detail/floating_point_weight.h"
 
@@ -54,10 +55,8 @@ namespace cppsort
         auto total_greater(T lhs, T rhs)
             -> std::enable_if_t<std::is_floating_point<T>::value, bool>
         {
-            if (std::isfinite(lhs) && std::isfinite(rhs))
-            {
-                if (lhs == 0 && rhs == 0)
-                {
+            if (std::isfinite(lhs) && std::isfinite(rhs)) {
+                if (lhs == 0 && rhs == 0) {
                     return std::signbit(rhs) && not std::signbit(lhs);
                 }
                 return lhs > rhs;
@@ -88,6 +87,16 @@ namespace cppsort
         constexpr auto&& total_greater = utility::static_const<
             detail::total_greater_fn
         >::value;
+    }
+
+    // Branchless traits
+
+    namespace utility
+    {
+        template<typename T>
+        struct is_probably_branchless_comparison<decltype(total_greater), T>:
+            std::is_integral<T>
+        {};
     }
 }
 

--- a/include/cpp-sort/comparators/total_less.h
+++ b/include/cpp-sort/comparators/total_less.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <type_traits>
 #include <utility>
+#include <cpp-sort/utility/branchless_traits.h>
 #include <cpp-sort/utility/static_const.h>
 #include "../detail/floating_point_weight.h"
 
@@ -54,10 +55,8 @@ namespace cppsort
         auto total_less(T lhs, T rhs)
             -> std::enable_if_t<std::is_floating_point<T>::value, bool>
         {
-            if (std::isfinite(lhs) && std::isfinite(rhs))
-            {
-                if (lhs == 0 && rhs == 0)
-                {
+            if (std::isfinite(lhs) && std::isfinite(rhs)) {
+                if (lhs == 0 && rhs == 0) {
                     return std::signbit(lhs) && not std::signbit(rhs);
                 }
                 return lhs < rhs;
@@ -88,6 +87,16 @@ namespace cppsort
         constexpr auto&& total_less = utility::static_const<
             detail::total_less_fn
         >::value;
+    }
+
+    // Branchless traits
+
+    namespace utility
+    {
+        template<typename T>
+        struct is_probably_branchless_comparison<decltype(total_less), T>:
+            std::is_integral<T>
+        {};
     }
 }
 

--- a/include/cpp-sort/comparators/weak_greater.h
+++ b/include/cpp-sort/comparators/weak_greater.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@
 #include <type_traits>
 #include <utility>
 #include <cpp-sort/comparators/total_greater.h>
+#include <cpp-sort/utility/branchless_traits.h>
 #include <cpp-sort/utility/static_const.h>
 #include "../detail/floating_point_weight.h"
 
@@ -45,8 +46,7 @@ namespace cppsort
         auto weak_greater(T lhs, T rhs)
             -> std::enable_if_t<std::is_floating_point<T>::value, bool>
         {
-            if (std::isfinite(lhs) && std::isfinite(rhs))
-            {
+            if (std::isfinite(lhs) && std::isfinite(rhs)) {
                 return lhs > rhs;
             }
 
@@ -86,6 +86,16 @@ namespace cppsort
         constexpr auto&& weak_greater = utility::static_const<
             detail::weak_greater_fn
         >::value;
+    }
+
+    // Branchless traits
+
+    namespace utility
+    {
+        template<typename T>
+        struct is_probably_branchless_comparison<decltype(weak_greater), T>:
+            std::is_integral<T>
+        {};
     }
 }
 

--- a/include/cpp-sort/comparators/weak_less.h
+++ b/include/cpp-sort/comparators/weak_less.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@
 #include <type_traits>
 #include <utility>
 #include <cpp-sort/comparators/total_less.h>
+#include <cpp-sort/utility/branchless_traits.h>
 #include <cpp-sort/utility/static_const.h>
 #include "../detail/floating_point_weight.h"
 
@@ -45,8 +46,7 @@ namespace cppsort
         auto weak_less(T lhs, T rhs)
             -> std::enable_if_t<std::is_floating_point<T>::value, bool>
         {
-            if (std::isfinite(lhs) && std::isfinite(rhs))
-            {
+            if (std::isfinite(lhs) && std::isfinite(rhs)) {
                 return lhs < rhs;
             }
 
@@ -86,6 +86,16 @@ namespace cppsort
         constexpr auto&& weak_less = utility::static_const<
             detail::weak_less_fn
         >::value;
+    }
+
+    // Branchless traits
+
+    namespace utility
+    {
+        template<typename T>
+        struct is_probably_branchless_comparison<decltype(weak_less), T>:
+            std::is_integral<T>
+        {};
     }
 }
 

--- a/include/cpp-sort/utility/branchless_traits.h
+++ b/include/cpp-sort/utility/branchless_traits.h
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_UTILITY_BRANCHLESS_TRAITS_H_
+#define CPPSORT_UTILITY_BRANCHLESS_TRAITS_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <functional>
+#include <type_traits>
+#include <cpp-sort/utility/logical_traits.h>
+
+namespace cppsort
+{
+namespace utility
+{
+    ////////////////////////////////////////////////////////////
+    // Whether a comparison function is likely branchless when
+    // called with instances of a specific type
+
+    namespace detail
+    {
+        template<typename Compare, typename T>
+        struct is_probably_branchless_comparison_impl:
+            std::false_type
+        {};
+
+        template<typename T>
+        struct is_probably_branchless_comparison_impl<std::less<>, T>:
+            std::is_arithmetic<T>
+        {};
+
+        template<typename T>
+        struct is_probably_branchless_comparison_impl<std::less<T>, T>:
+            std::is_arithmetic<T>
+        {};
+
+        template<typename T>
+        struct is_probably_branchless_comparison_impl<std::greater<>, T>:
+            std::is_arithmetic<T>
+        {};
+
+        template<typename T>
+        struct is_probably_branchless_comparison_impl<std::greater<T>, T>:
+            std::is_arithmetic<T>
+        {};
+    }
+
+    // Strip types from cv and reference qualifications if needed
+
+    template<typename Compare, typename T>
+    struct is_probably_branchless_comparison:
+        std::conditional_t<
+            disjunction<
+                std::is_reference<Compare>,
+                std::is_const<Compare>,
+                std::is_volatile<Compare>,
+                std::is_reference<T>,
+                std::is_const<T>,
+                std::is_volatile<T>
+            >::value,
+            is_probably_branchless_comparison<
+                std::remove_cv_t<std::remove_reference_t<Compare>>,
+                std::remove_cv_t<std::remove_reference_t<T>>
+            >,
+            detail::is_probably_branchless_comparison_impl<Compare, T>
+        >
+    {};
+
+    ////////////////////////////////////////////////////////////
+    // Whether a projection function is likely branchless when
+    // called with an instance of a specific type
+
+    namespace detail
+    {
+        template<typename Projection, typename T>
+        struct is_probably_branchless_projection_impl:
+            std::is_member_object_pointer<Projection>
+        {};
+    }
+
+    // Strip types from cv and reference qualifications if needed
+
+    template<typename Projection, typename T>
+    struct is_probably_branchless_projection:
+        std::conditional_t<
+            disjunction<
+                std::is_reference<Projection>,
+                std::is_const<Projection>,
+                std::is_volatile<Projection>,
+                std::is_reference<T>,
+                std::is_const<T>,
+                std::is_volatile<T>
+            >::value,
+            is_probably_branchless_projection<
+                std::remove_cv_t<std::remove_reference_t<Projection>>,
+                std::remove_cv_t<std::remove_reference_t<T>>
+            >,
+            detail::is_probably_branchless_projection_impl<Projection, T>
+        >
+    {};
+}}
+
+#endif // CPPSORT_UTILITY_BRANCHLESS_TRAITS_H_

--- a/include/cpp-sort/utility/functional.h
+++ b/include/cpp-sort/utility/functional.h
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <type_traits>
 #include <utility>
+#include <cpp-sort/utility/branchless_traits.h>
 
 namespace cppsort
 {
@@ -49,6 +50,11 @@ namespace utility
 
         using is_transparent = void;
     };
+
+    template<typename T>
+    struct is_probably_branchless_projection<identity, T>:
+        std::true_type
+    {};
 
     ////////////////////////////////////////////////////////////
     // Transform overload in unary or binary function

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -92,6 +92,7 @@ set(
 
     utility/as_projection.cpp
     utility/as_projection_iterable.cpp
+    utility/branchless_traits.cpp
     utility/buffer.cpp
     utility/iter_swap.cpp
 )

--- a/testsuite/utility/branchless_traits.cpp
+++ b/testsuite/utility/branchless_traits.cpp
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <functional>
+#include <string>
+#include <catch.hpp>
+#include <cpp-sort/comparators/partial_less.h>
+#include <cpp-sort/comparators/total_less.h>
+#include <cpp-sort/comparators/weak_less.h>
+#include <cpp-sort/utility/branchless_traits.h>
+#include <cpp-sort/utility/functional.h>
+
+TEST_CASE( "test that some specific comparisons are branchless",
+           "[utility][branchless][comparison]" )
+{
+    using namespace cppsort::utility;
+
+    SECTION( "standard library function objects" )
+    {
+        CHECK(( is_probably_branchless_comparison<std::less<int>, int>::value ));
+        CHECK(( is_probably_branchless_comparison<std::less<>, int>::value ));
+        CHECK(( is_probably_branchless_comparison<std::less<long double>, long double>::value ));
+
+        CHECK(( is_probably_branchless_comparison<std::greater<int>, int>::value ));
+        CHECK(( is_probably_branchless_comparison<std::greater<>, int>::value ));
+        CHECK(( is_probably_branchless_comparison<std::greater<long double>, long double>::value ));
+
+        CHECK_FALSE(( is_probably_branchless_comparison<std::less<std::string>, std::string>::value ));
+        CHECK_FALSE(( is_probably_branchless_comparison<std::less<>, std::string>::value ));
+    }
+
+    SECTION( "partial/weak/less function objects" )
+    {
+        using partial_t = decltype(cppsort::partial_less);
+        using weak_t = decltype(cppsort::weak_less);
+        using total_t = decltype(cppsort::total_less);
+
+        CHECK(( is_probably_branchless_comparison<partial_t, int>::value ));
+        CHECK(( is_probably_branchless_comparison<weak_t, int>::value ));
+        CHECK(( is_probably_branchless_comparison<total_t, int>::value ));
+
+        CHECK(( is_probably_branchless_comparison<partial_t, float>::value ));
+        CHECK_FALSE(( is_probably_branchless_comparison<weak_t, float>::value ));
+        CHECK_FALSE(( is_probably_branchless_comparison<total_t, float>::value ));
+
+        CHECK_FALSE(( is_probably_branchless_comparison<partial_t, std::string>::value ));
+        CHECK_FALSE(( is_probably_branchless_comparison<weak_t, std::string>::value ));
+        CHECK_FALSE(( is_probably_branchless_comparison<total_t, std::string>::value ));
+    }
+
+    SECTION( "cv-qualified and reference-qualified types" )
+    {
+        CHECK(( is_probably_branchless_comparison<std::less<>, const int>::value ));
+        CHECK(( is_probably_branchless_comparison<const std::less<>&, int>::value ));
+        CHECK(( is_probably_branchless_comparison<const std::greater<>, int&&>::value ));
+    }
+}
+
+TEST_CASE( "test that some specific projections are branchless",
+           "[utility][branchless][projection]" )
+{
+    using namespace cppsort::utility;
+
+    struct foobar
+    {
+        int foo;
+        int bar() { return 0; }
+    };
+
+    CHECK(( is_probably_branchless_projection<identity, std::string>::value ));
+
+    CHECK(( is_probably_branchless_projection<decltype(&foobar::foo), foobar>::value ));
+    CHECK_FALSE(( is_probably_branchless_projection<decltype(&foobar::bar), foobar>::value ));
+}


### PR DESCRIPTION
Add user-specializable traits to detect branchless comparison and projection functions. Update `pdq_sorter` to take these traits into account to pick the appropriate partitioning functions to use. This reflects the latest design changes in orlp/pdqsort while allowing users to provide additional information.