### PR TITLE
Globally seed the testsuite PRNGs from the command line (fixes #108)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ script:
   - cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DSANITIZE="${SANITIZE}" .
   - make
   - if [ "${VALGRIND}" = "true" ]; then
-      travis_wait valgrind --leak-check=full --track-origins=yes testsuite/cpp-sort-testsuite;
+      travis_wait valgrind --leak-check=full --track-origins=yes testsuite/cpp-sort-testsuite --rng-seed $RANDOM;
     else
-      testsuite/cpp-sort-testsuite;
+      testsuite/cpp-sort-testsuite --rng-seed $RANDOM;
     fi
 
 notifications:

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -1,0 +1,20 @@
+**cpp-sort**'s testsuite uses the framework [Catch][1], and can be built from the project's root directory with the
+following commands (requires [CMake][2] to be installed):
+
+```bash
+cmake .
+make
+testsuite/cpp-sort-testsuite;
+```
+
+If GCC or Clang sanitizers are availbale, `cmake` can be passed the configuration variable `-DSANITIZE=san` with any
+value `san` such as `san` can be given to the compilers as `-fsanitize=san`.
+
+The testsuite executable, being build with Catch, can notably take the option `--rng-seed` to seed the pseudo-random
+number generators throughout the testsuite. If not provided, `0` will be used instead. See [Catch's documentation][3]
+for more information about the possible testsuite options.
+
+
+  [1]: https://github.com/philsquared/Catch
+  [2]: https://cmake.org/
+  [3]: https://github.com/philsquared/Catch/blob/master/docs/command-line.md

--- a/testsuite/adapters/counting_adapter.cpp
+++ b/testsuite/adapters/counting_adapter.cpp
@@ -23,7 +23,6 @@
  */
 #include <algorithm>
 #include <cstddef>
-#include <ctime>
 #include <iterator>
 #include <list>
 #include <numeric>
@@ -66,7 +65,7 @@ TEST_CASE( "basic counting_adapter tests",
         struct wrapper { int value; };
 
         // Pseudo-random number engine
-        std::mt19937_64 engine(std::time(nullptr));
+        std::mt19937_64 engine(Catch::rngSeed());
 
         // Fill the collection
         std::vector<wrapper> tmp(80);
@@ -127,7 +126,7 @@ TEST_CASE( "counting_adapter with span",
         struct wrapper { int value; };
 
         // Pseudo-random number engine
-        std::mt19937_64 engine(std::time(nullptr));
+        std::mt19937_64 engine(Catch::rngSeed());
 
         // Fill the collection
         std::vector<wrapper> tmp(80);

--- a/testsuite/adapters/mixed_adapters.cpp
+++ b/testsuite/adapters/mixed_adapters.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <functional>
 #include <iterator>
 #include <list>
@@ -48,7 +47,7 @@ TEST_CASE( "indirect sort with Schwartzian transform",
 
     std::vector<wrapper> collection(334);
     helpers::iota(std::begin(collection), std::end(collection), -93, &wrapper::value);
-    std::mt19937 engine(std::time(nullptr));
+    std::mt19937 engine(Catch::rngSeed());
     std::shuffle(std::begin(collection), std::end(collection), engine);
 
     SECTION( "schwartz_adapter over indirect_adapter" )

--- a/testsuite/adapters/schwartz_adapter_every_sorter.cpp
+++ b/testsuite/adapters/schwartz_adapter_every_sorter.cpp
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <iterator>
 #include <random>
 #include <string>
@@ -48,7 +47,7 @@ TEST_CASE( "every sorter with Schwartzian transform adapter",
 {
     std::vector<wrapper<>> collection(412);
     helpers::iota(std::begin(collection), std::end(collection), -125, &wrapper<>::value);
-    std::mt19937 engine(std::time(nullptr));
+    std::mt19937 engine(Catch::rngSeed());
     std::shuffle(std::begin(collection), std::end(collection), engine);
 
     SECTION( "block_sorter" )

--- a/testsuite/adapters/schwartz_adapter_fixed_sorters.cpp
+++ b/testsuite/adapters/schwartz_adapter_fixed_sorters.cpp
@@ -23,7 +23,6 @@
  */
 #include <algorithm>
 #include <array>
-#include <ctime>
 #include <iterator>
 #include <random>
 #include <catch.hpp>
@@ -54,7 +53,7 @@ TEST_CASE( "Schwartzian transform adapter with fixed-size sorters",
         >
     >{};
 
-    std::mt19937 engine(std::time(nullptr));
+    std::mt19937 engine(Catch::rngSeed());
 
     SECTION( "size 0" )
     {

--- a/testsuite/adapters/stable_adapter_every_sorter.cpp
+++ b/testsuite/adapters/stable_adapter_every_sorter.cpp
@@ -24,7 +24,6 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
-#include <ctime>
 #include <iterator>
 #include <random>
 #include <vector>
@@ -65,7 +64,7 @@ TEST_CASE( "every sorter with stable adapter",
     {
         wrap.value = count++ % 17;
     }
-    std::mt19937 engine(std::time(nullptr));
+    std::mt19937 engine(Catch::rngSeed());
     std::shuffle(std::begin(collection), std::end(collection), engine);
     count = 0;
     for (wrapper& wrap: collection)

--- a/testsuite/distributions.h
+++ b/testsuite/distributions.h
@@ -32,12 +32,8 @@
 #include <iterator>
 #include <random>
 #include <vector>
+#include <catch.hpp>
 #include <cpp-sort/utility/bitops.h>
-
-#ifdef __MINGW32__
-    // Poor seed for the pseudo-random number generation
-#   include <ctime>
-#endif
 
 namespace dist
 {
@@ -64,11 +60,7 @@ namespace dist
             -> void
         {
             // Pseudo-random number generator
-#ifdef __MINGW32__
-            thread_local std::mt19937 engine(std::time(nullptr));
-#else
-            thread_local std::mt19937 engine(std::random_device{}());
-#endif
+            thread_local std::mt19937 engine(Catch::rngSeed());
 
             std::vector<T> vec;
             vec.reserve(size);
@@ -90,11 +82,7 @@ namespace dist
             -> void
         {
             // Pseudo-random number generator
-#ifdef __MINGW32__
-            thread_local std::mt19937 engine(std::time(nullptr));
-#else
-            thread_local std::mt19937 engine(std::random_device{}());
-#endif
+            thread_local std::mt19937 engine(Catch::rngSeed());
 
             std::vector<int> vec;
             vec.reserve(size);

--- a/testsuite/every_sorter_move_only.cpp
+++ b/testsuite/every_sorter_move_only.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <iterator>
 #include <random>
 #include <vector>
@@ -44,7 +43,7 @@ TEST_CASE( "test every sorter with move-only types", "[sorters]" )
     {
         collection.emplace_back(i);
     }
-    std::mt19937 engine(std::time(nullptr));
+    std::mt19937 engine(Catch::rngSeed());
     std::shuffle(std::begin(collection), std::end(collection), engine);
 
     SECTION( "block_sorter" )

--- a/testsuite/every_sorter_no_post_iterator.cpp
+++ b/testsuite/every_sorter_no_post_iterator.cpp
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <iterator>
 #include <random>
 #include <vector>
@@ -39,7 +38,7 @@ TEST_CASE( "test every sorter with no_post_iterator", "[sorters]" )
     for (long i = 56 ; i < 366 ; ++i) {
         collection.emplace_back(i);
     }
-    std::mt19937 engine(std::time(nullptr));
+    std::mt19937 engine(Catch::rngSeed());
     std::shuffle(std::begin(collection), std::end(collection), engine);
 
     // Iterators with no post-increment and no post-decrement

--- a/testsuite/sorters/default_sorter_projection.cpp
+++ b/testsuite/sorters/default_sorter_projection.cpp
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <forward_list>
 #include <functional>
 #include <iterator>
@@ -38,7 +37,7 @@ TEST_CASE( "default sorter tests with projections",
            "[default_sorter][projection]" )
 {
     // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    std::mt19937_64 engine(Catch::rngSeed());
 
     // Wrapper to hide the integer
     struct wrapper { int value; };

--- a/testsuite/sorters/merge_insertion_sorter_projection.cpp
+++ b/testsuite/sorters/merge_insertion_sorter_projection.cpp
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <functional>
 #include <iterator>
 #include <random>
@@ -36,7 +35,7 @@ TEST_CASE( "merge_insertion_sorter tests with projections",
            "[merge_insertion_sorter][projection]" )
 {
     // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    std::mt19937_64 engine(Catch::rngSeed());
 
     // Wrapper to hide the integer
     struct wrapper { int value; };

--- a/testsuite/sorters/merge_sorter_projection.cpp
+++ b/testsuite/sorters/merge_sorter_projection.cpp
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <forward_list>
 #include <functional>
 #include <iterator>
@@ -38,7 +37,7 @@ TEST_CASE( "merge_sorter tests with projections",
            "[merge_sorter][projection]" )
 {
     // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    std::mt19937_64 engine(Catch::rngSeed());
 
     // Wrapper to hide the integer
     struct wrapper { int value; };

--- a/testsuite/sorters/ska_sorter.cpp
+++ b/testsuite/sorters/ska_sorter.cpp
@@ -23,7 +23,6 @@
  */
 #include <algorithm>
 #include <cstdint>
-#include <ctime>
 #include <deque>
 #include <iterator>
 #include <limits>
@@ -40,7 +39,7 @@
 TEST_CASE( "ska_sorter tests", "[ska_sorter]" )
 {
     // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    std::mt19937_64 engine(Catch::rngSeed());
 
     SECTION( "sort with int iterable" )
     {

--- a/testsuite/sorters/ska_sorter_projection.cpp
+++ b/testsuite/sorters/ska_sorter_projection.cpp
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <functional>
 #include <iterator>
 #include <random>
@@ -37,7 +36,7 @@ TEST_CASE( "ska_sorter tests with projections",
            "[ska_sorter][projection]" )
 {
     // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    std::mt19937_64 engine(Catch::rngSeed());
 
     SECTION( "sort with int iterable" )
     {

--- a/testsuite/sorters/spread_sorter.cpp
+++ b/testsuite/sorters/spread_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2016 Morwenn
+ * Copyright (c) 2015-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <iterator>
 #include <numeric>
 #include <random>
@@ -35,7 +34,7 @@
 TEST_CASE( "spread_sorter tests", "[spread_sorter]" )
 {
     // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    std::mt19937_64 engine(Catch::rngSeed());
 
     SECTION( "sort with int iterable" )
     {

--- a/testsuite/sorters/spread_sorter_defaults.cpp
+++ b/testsuite/sorters/spread_sorter_defaults.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2016 Morwenn
+ * Copyright (c) 2015-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <functional>
 #include <iterator>
 #include <numeric>
@@ -41,7 +40,7 @@ TEST_CASE( "spread_sorter generate overloads",
     // operator() overloads for non-comparison sorters
 
     // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    std::mt19937_64 engine(Catch::rngSeed());
 
     SECTION( "default operator() with std::less<>" )
     {

--- a/testsuite/sorters/spread_sorter_projection.cpp
+++ b/testsuite/sorters/spread_sorter_projection.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <functional>
 #include <iterator>
 #include <random>
@@ -37,7 +36,7 @@ TEST_CASE( "spread_sorter tests with projections",
            "[spread_sorter][projection]" )
 {
     // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    std::mt19937_64 engine(Catch::rngSeed());
 
     SECTION( "sort with int iterable" )
     {

--- a/testsuite/sorters/std_sorter.cpp
+++ b/testsuite/sorters/std_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <functional>
 #include <iterator>
 #include <numeric>
@@ -36,7 +35,7 @@
 TEST_CASE( "std_sorter tests", "[std_sorter]" )
 {
     // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    std::mt19937_64 engine(Catch::rngSeed());
 
     // Collection to sort
     std::vector<int> vec(80);
@@ -72,7 +71,7 @@ TEST_CASE( "std_sorter tests with projections",
            "[std_sorter][projection]" )
 {
     // Pseudo-random number engine
-    std::mt19937_64 engine(std::time(nullptr));
+    std::mt19937_64 engine(Catch::rngSeed());
 
     // Wrapper to hide the integer
     struct wrapper { int value; };

--- a/testsuite/utility/as_projection.cpp
+++ b/testsuite/utility/as_projection.cpp
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <functional>
 #include <iterator>
 #include <numeric>
@@ -62,7 +61,7 @@ TEST_CASE( "try mixed comparison/projection function object",
 {
     std::vector<int> collection(100);
     std::iota(std::begin(collection), std::end(collection), 0);
-    std::mt19937 engine(std::time(nullptr));
+    std::mt19937 engine(Catch::rngSeed());
     std::shuffle(std::begin(collection), std::end(collection), engine);
 
     tricky_function func;

--- a/testsuite/utility/as_projection_iterable.cpp
+++ b/testsuite/utility/as_projection_iterable.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2016 Morwenn
+ * Copyright (c) 2016-2017 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
-#include <ctime>
 #include <functional>
 #include <iterator>
 #include <numeric>
@@ -148,7 +147,7 @@ TEST_CASE( "sorter_facade with sorters overloaded for iterables and mixed compar
     // Collection to sort
     std::vector<int> collection(100);
     std::iota(std::begin(collection), std::end(collection), 0);
-    std::mt19937 engine(std::time(nullptr));
+    std::mt19937 engine(Catch::rngSeed());
     std::shuffle(std::begin(collection), std::end(collection), engine);
     auto vec = collection;
 


### PR DESCRIPTION
Unfortunately, it only solves the problem of Catch failing tests, and does not help when Valgrind or a sanitizer fails. I'll leave it as is for now, but may add an unconditional dump of the seed, even when nothing is failing, just to make sure that it's logged when Valgrind or a sanitizer fails.

[ci skip]