### PR TITLE
Build overhaul, fixes #65, fixes #90

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,12 +20,8 @@
 *.out
 *.app
 
-# CMake files and Makefile
-CMakeCache.txt
-CMakeFiles
-Makefile
-*.cmake
-install_manifest.txt
+# Build directory
+build
 
 # Code::Blocks files
 *.cbp
@@ -42,6 +38,3 @@ CppCheckResults.xml
 *.png
 *.pdf
 *.synctex.gz
-
-# Downloaded Catch files
-catch

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,27 +71,6 @@ matrix:
       env: BUILD_TYPE=Release VALGRIND=false SANITIZE='' CMAKE_GENERATOR="Xcode"
       compiler: clang
 
-    # OSX gcc
-    - os: osx
-      osx_image: xcode8
-      env: BUILD_TYPE=Debug VALGRIND=true SANITIZE='' CMAKE_GENERATOR="Xcode"
-      compiler: gcc
-
-    - os: osx
-      osx_image: xcode8
-      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=undefined CMAKE_GENERATOR="Xcode"
-      compiler: gcc
-
-    - os: osx
-      osx_image: xcode8
-      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=address CMAKE_GENERATOR="Xcode"
-      compiler: gcc
-
-    - os: osx
-      osx_image: xcode8
-      env: BUILD_TYPE=Release VALGRIND=false SANITIZE='' CMAKE_GENERATOR="Xcode"
-      compiler: gcc
-
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5"; fi
   - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
       compiler: clang
 
     - os: linux
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=address
+      compiler: clang
+
+    - os: linux
       env: BUILD_TYPE=Release VALGRIND=false SANITIZE=''
       compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,10 @@ install:
   - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8"; fi
 
 script: 
-  - cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DSANITIZE="${SANITIZE}" .
-  - make
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DSANITIZE="${SANITIZE}" ..
+  - cmake --build .
   - if [ "${VALGRIND}" = "true" ]; then
       travis_wait valgrind --leak-check=full --track-origins=yes --error-exitcode=1 testsuite/cpp-sort-testsuite --rng-seed $RANDOM;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,6 @@ language: cpp
 
 sudo: false
 
-compiler:
-  - clang
-  - gcc
-
-env:
-  - BUILD_TYPE=Debug    VALGRIND=true   SANITIZE='' 
-  - BUILD_TYPE=Debug    VALGRIND=false  SANITIZE=undefined 
-#  - BUILD_TYPE=Debug    VALGRIND=false  SANITIZE=address 
-  - BUILD_TYPE=Release  VALGRIND=false  SANITIZE=''
-
 addons:
   apt:
     sources:
@@ -22,6 +12,35 @@ addons:
       - g++-5
       - valgrind
 
+matrix:
+  include:
+
+    # clang
+    - os: linux
+      env: BUILD_TYPE=Debug VALGRIND=true SANITIZE=''
+      compiler: clang
+
+    - os: linux
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=undefined
+      compiler: clang
+
+    - os: linux
+      env: BUILD_TYPE=Release VALGRIND=false SANITIZE=''
+      compiler: clang
+
+    # gcc
+    - os: linux
+      env: BUILD_TYPE=Debug VALGRIND=true SANITIZE=''
+      compiler: gcc
+
+    - os: linux
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=undefined
+      compiler: gcc
+
+    - os: linux
+      env: BUILD_TYPE=Release VALGRIND=false SANITIZE=''
+      compiler: gcc
+
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5"; fi
   - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8"; fi
@@ -29,7 +48,9 @@ install:
 script: 
   - mkdir build
   - cd build
-  - cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DSANITIZE="${SANITIZE}" ..
+  - cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
+          -DSANITIZE="${SANITIZE}"
+          ..
   - cmake --build .
   - if [ "${VALGRIND}" = "true" ]; then
       travis_wait valgrind --leak-check=full --track-origins=yes --error-exitcode=1 testsuite/cpp-sort-testsuite --rng-seed $RANDOM;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: cpp
 
-sudo: false
-
 addons:
   apt:
     sources:
@@ -15,34 +13,83 @@ addons:
 matrix:
   include:
 
-    # clang
+    # Linux clang
     - os: linux
-      env: BUILD_TYPE=Debug VALGRIND=true SANITIZE=''
+      sudo: false
+      env: BUILD_TYPE=Debug VALGRIND=true SANITIZE='' CMAKE_GENERATOR="Unix Makefiles"
       compiler: clang
 
     - os: linux
-      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=undefined
+      sudo: false
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=undefined CMAKE_GENERATOR="Unix Makefiles"
       compiler: clang
 
     - os: linux
-      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=address
+      sudo: false
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=address CMAKE_GENERATOR="Unix Makefiles"
       compiler: clang
 
     - os: linux
-      env: BUILD_TYPE=Release VALGRIND=false SANITIZE=''
+      sudo: false
+      env: BUILD_TYPE=Release VALGRIND=false SANITIZE='' CMAKE_GENERATOR="Unix Makefiles"
       compiler: clang
 
-    # gcc
+    # Linux gcc
     - os: linux
-      env: BUILD_TYPE=Debug VALGRIND=true SANITIZE=''
+      sudo: false
+      env: BUILD_TYPE=Debug VALGRIND=true SANITIZE='' CMAKE_GENERATOR="Unix Makefiles"
       compiler: gcc
 
     - os: linux
-      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=undefined
+      sudo: false
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=undefined CMAKE_GENERATOR="Unix Makefiles"
       compiler: gcc
 
     - os: linux
-      env: BUILD_TYPE=Release VALGRIND=false SANITIZE=''
+      sudo: false
+      env: BUILD_TYPE=Release VALGRIND=false SANITIZE='' CMAKE_GENERATOR="Unix Makefiles"
+      compiler: gcc
+
+    # OSX clang
+    - os: osx
+      osx_image: xcode8
+      env: BUILD_TYPE=Debug VALGRIND=true SANITIZE='' CMAKE_GENERATOR="Xcode"
+      compiler: clang
+
+    - os: osx
+      osx_image: xcode8
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=undefined CMAKE_GENERATOR="Xcode"
+      compiler: clang
+
+    - os: osx
+      osx_image: xcode8
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=address CMAKE_GENERATOR="Xcode"
+      compiler: clang
+
+    - os: osx
+      osx_image: xcode8
+      env: BUILD_TYPE=Release VALGRIND=false SANITIZE='' CMAKE_GENERATOR="Xcode"
+      compiler: clang
+
+    # OSX gcc
+    - os: osx
+      osx_image: xcode8
+      env: BUILD_TYPE=Debug VALGRIND=true SANITIZE='' CMAKE_GENERATOR="Xcode"
+      compiler: gcc
+
+    - os: osx
+      osx_image: xcode8
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=undefined CMAKE_GENERATOR="Xcode"
+      compiler: gcc
+
+    - os: osx
+      osx_image: xcode8
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=address CMAKE_GENERATOR="Xcode"
+      compiler: gcc
+
+    - os: osx
+      osx_image: xcode8
+      env: BUILD_TYPE=Release VALGRIND=false SANITIZE='' CMAKE_GENERATOR="Xcode"
       compiler: gcc
 
 install:
@@ -54,6 +101,7 @@ script:
   - cd build
   - cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
           -DSANITIZE="${SANITIZE}"
+          -G"${CMAKE_GENERATOR}"
           ..
   - cmake --build .
   - if [ "${VALGRIND}" = "true" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,12 @@ install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5"; fi
   - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8"; fi
 
-script: 
+script:
+  - case `uname` in
+        Darwin) export EXECUTABLE_DIR="testsuite/Debug";;
+        Linux) export EXECUTABLE_DIR="testsuite";;
+    esac
+
   - mkdir build
   - cd build
   - cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
@@ -84,9 +89,9 @@ script:
           ..
   - cmake --build .
   - if [ "${VALGRIND}" = "true" ]; then
-      travis_wait valgrind --leak-check=full --track-origins=yes --error-exitcode=1 testsuite/cpp-sort-testsuite --rng-seed $RANDOM;
+        travis_wait valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $EXECUTABLE_DIR/cpp-sort-testsuite --rng-seed $RANDOM;
     else
-      testsuite/cpp-sort-testsuite --rng-seed $RANDOM;
+        $EXECUTABLE_DIR/cpp-sort-testsuite --rng-seed $RANDOM;
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,16 +58,6 @@ matrix:
 
     - os: osx
       osx_image: xcode8
-      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=undefined CMAKE_GENERATOR="Xcode"
-      compiler: clang
-
-    - os: osx
-      osx_image: xcode8
-      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=address CMAKE_GENERATOR="Xcode"
-      compiler: clang
-
-    - os: osx
-      osx_image: xcode8
       env: BUILD_TYPE=Release VALGRIND=false SANITIZE='' CMAKE_GENERATOR="Xcode"
       compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,9 @@ matrix:
       env: BUILD_TYPE=Release VALGRIND=false SANITIZE='' CMAKE_GENERATOR="Xcode"
       compiler: clang
 
+before_install:
+  - if [ `uname` = 'Darwin' ]; then brew update && brew install valgrind; fi
+
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5"; fi
   - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8"; fi

--- a/external/catch/CMakeLists.txt
+++ b/external/catch/CMakeLists.txt
@@ -18,3 +18,6 @@ ExternalProject_Add(
 # Expose required variable (CATCH_INCLUDE_DIR) to parent scope
 ExternalProject_Get_Property(catch source_dir)
 set(CATCH_INCLUDE_DIR ${source_dir}/include CACHE INTERNAL "Path to include folder for Catch")
+
+add_library(Catch INTERFACE)
+target_include_directories(Catch INTERFACE ${CATCH_INCLUDE_DIR})

--- a/external/catch/CMakeLists.txt
+++ b/external/catch/CMakeLists.txt
@@ -18,6 +18,3 @@ ExternalProject_Add(
 # Expose required variable (CATCH_INCLUDE_DIR) to parent scope
 ExternalProject_Get_Property(catch source_dir)
 set(CATCH_INCLUDE_DIR ${source_dir}/include CACHE INTERNAL "Path to include folder for Catch")
-
-add_library(Catch INTERFACE)
-target_include_directories(Catch INTERFACE ${CATCH_INCLUDE_DIR})

--- a/include/cpp-sort/utility/buffer.h
+++ b/include/cpp-sort/utility/buffer.h
@@ -109,6 +109,78 @@ namespace utility
         };
     };
 
+    template<>
+    struct fixed_buffer<0>
+    {
+        // Not sure how to handle this one, but buffered sorters should
+        // tolerate 0-sized buffers and do nothing with them; we take a
+        // somewhat hazardous route and make some things rely on a 1-sized
+        // std::array
+
+        template<typename T>
+        struct buffer
+        {
+            buffer() = default;
+            explicit constexpr buffer(std::size_t /* size */) {}
+
+            constexpr auto size() const
+                -> typename std::array<T, 1>::size_type
+            {
+                return 0;
+            }
+
+            constexpr auto operator[](std::size_t pos)
+                -> typename std::array<T, 1>::reference
+            {
+                // Should never be called
+                return begin()[pos];
+            }
+
+            constexpr auto operator[](std::size_t pos) const
+                -> typename std::array<T, 1>::const_reference
+            {
+                // Should never be called
+                return begin()[pos];
+            }
+
+            constexpr auto begin()
+                -> typename std::array<T, 1>::pointer
+            {
+                return nullptr;
+            }
+
+            constexpr auto begin() const
+                -> typename std::array<T, 1>::const_pointer
+            {
+                return nullptr;
+            }
+
+            constexpr auto cbegin() const
+                -> typename std::array<T, 1>::const_pointer
+            {
+                return nullptr;
+            }
+
+            constexpr auto end()
+                -> typename std::array<T, 1>::pointer
+            {
+                return nullptr;
+            }
+
+            constexpr auto end() const
+                -> typename std::array<T, 1>::const_pointer
+            {
+                return nullptr;
+            }
+
+            constexpr auto cend() const
+                -> typename std::array<T, 1>::const_pointer
+            {
+                return nullptr;
+            }
+        };
+    };
+
     ////////////////////////////////////////////////////////////
     // Dynamic buffer accepting a size policy
 

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -122,6 +122,8 @@ add_executable(
     ${UTILITY_TESTS}
 )
 
+add_dependencies(cpp-sort-testsuite Catch)
+
 add_test(testsuite cpp-sort-testsuite)
 
 # Enable unit-testing

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -122,6 +122,7 @@ add_executable(
     ${UTILITY_TESTS}
 )
 
+add_dependencies(cpp-sort-testsuite catch)
 add_dependencies(cpp-sort-testsuite Catch)
 
 add_test(testsuite cpp-sort-testsuite)

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -123,7 +123,6 @@ add_executable(
 )
 
 add_dependencies(cpp-sort-testsuite catch)
-add_dependencies(cpp-sort-testsuite Catch)
 
 add_test(testsuite cpp-sort-testsuite)
 


### PR DESCRIPTION
Several changes to the Travis builds:
* Manually hand-roll the build matrix to handle specific cases
* Builds everything in a `build` subdirectory
* Builds on OSX with Xcode 8, with and without Valgrind
* Build with address sanitizer on Linux clang
* Proper build dependency in CMakeLists.txt
* Fix a bug to make clang builds work with libc++