### PR TITLE
Speed up CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ addons:
       - g++-5
       - valgrind
 
+cache:
+  apt: true
+  ccache: true
+
 matrix:
   include:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,11 @@ matrix:
 
     - os: linux
       sudo: false
+      env: BUILD_TYPE=Debug VALGRIND=false SANITIZE=address CMAKE_GENERATOR="Unix Makefiles"
+      compiler: gcc
+
+    - os: linux
+      sudo: false
       env: BUILD_TYPE=Release VALGRIND=false SANITIZE='' CMAKE_GENERATOR="Unix Makefiles"
       compiler: gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,20 +82,19 @@ install:
   - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8"; fi
 
 script:
-  - mkdir build
-  - cd build
-  - cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
+  - cmake -H. -Bbuild
+          -DCMAKE_CONFIGURATION_TYPES="${BUILD_TYPE}"
+          -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
           -DSANITIZE="${SANITIZE}"
           -DUSE_VALGRIND=${VALGRIND}
           -G"${CMAKE_GENERATOR}"
-          ..
   - if [ `uname` = 'Darwin' ]; then
-        cmake --build . -- -jobs 2;
+        cmake --build build --config ${BUILD_TYPE} -- -jobs 2;
     else
-        cmake --build . -- -j2;
+        cmake --build build --config ${BUILD_TYPE} -- -j2;
     fi
-  - cd testsuite
-  - ctest -C ${BUILD_TYPE} --output-on-failure
+  - cd build/testsuite
+  - travis_wait ctest -C ${BUILD_TYPE} --output-on-failure
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,12 @@ script:
           -DSANITIZE="${SANITIZE}"
           -G"${CMAKE_GENERATOR}"
           ..
-  - cmake --build .
+  - if [ `uname` = 'Darwin' ]; then
+        cmake --build . -- -jobs 2;
+    else
+        cmake --build . -- -j2;
+    fi
+
   - if [ "${VALGRIND}" = "true" ]; then
         travis_wait valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $EXECUTABLE_DIR/cpp-sort-testsuite --rng-seed $RANDOM;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,15 +82,11 @@ install:
   - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8"; fi
 
 script:
-  - case `uname` in
-        Darwin) export EXECUTABLE_DIR="testsuite/Debug";;
-        Linux) export EXECUTABLE_DIR="testsuite";;
-    esac
-
   - mkdir build
   - cd build
   - cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
           -DSANITIZE="${SANITIZE}"
+          -DUSE_VALGRIND=${VALGRIND}
           -G"${CMAKE_GENERATOR}"
           ..
   - if [ `uname` = 'Darwin' ]; then
@@ -98,12 +94,8 @@ script:
     else
         cmake --build . -- -j2;
     fi
-
-  - if [ "${VALGRIND}" = "true" ]; then
-        travis_wait valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $EXECUTABLE_DIR/cpp-sort-testsuite --rng-seed $RANDOM;
-    else
-        $EXECUTABLE_DIR/cpp-sort-testsuite --rng-seed $RANDOM;
-    fi
+  - cd testsuite
+  - ctest -C ${BUILD_TYPE} --output-on-failure
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,11 @@ matrix:
       compiler: clang
 
 before_install:
-  - if [ `uname` = 'Darwin' ]; then brew update && brew install valgrind; fi
+  - if [ `uname` = 'Darwin' ]; then
+        brew update &&
+        brew install ccache valgrind &&
+        export PATH="/usr/local/opt/ccache/libexec:$PATH";
+    fi
 
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5"; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ endif()
 
 # Optionally enable sanitizers
 if (UNIX AND SANITIZE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZE}")
+    foreach(SANITIZE_FLAG ${SANITIZE})
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZE_FLAG}")
+    endforeach()
 endif()
 
 # Include cpp-sort headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ cmake_minimum_required(VERSION 3.1.0)
 
 set(CMAKE_CXX_STANDARD 14)
 
+# Use the gold linker if possible
+if (UNIX AND NOT APPLE)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold")
+endif()
+
 # Optionally enable sanitizers
 if (UNIX AND SANITIZE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 3.1.0)
 # can optionally be built with CMake. This is what this script does.
 #
 
+option(USE_VALGRIND "whether to run the tests with Valgrind" OFF)
+
 set(CMAKE_CXX_STANDARD 14)
 
 # Use the gold linker if possible

--- a/external/catch/CMakeLists.txt
+++ b/external/catch/CMakeLists.txt
@@ -7,6 +7,7 @@ ExternalProject_Add(
     catch
     PREFIX ${CMAKE_BINARY_DIR}/catch
     GIT_REPOSITORY https://github.com/philsquared/Catch.git
+    GIT_TAG Catch1.x
     TIMEOUT 10
     UPDATE_COMMAND ${GIT_EXECUTABLE} pull
     CONFIGURE_COMMAND ""

--- a/external/catch/CMakeLists.txt
+++ b/external/catch/CMakeLists.txt
@@ -6,16 +6,15 @@ find_package(Git REQUIRED)
 ExternalProject_Add(
     catch
     PREFIX ${CMAKE_BINARY_DIR}/catch
-    GIT_REPOSITORY https://github.com/philsquared/Catch.git
-    GIT_TAG Catch1.x
+    GIT_REPOSITORY https://github.com/catchorg/Catch2
     TIMEOUT 10
     UPDATE_COMMAND ${GIT_EXECUTABLE} pull
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
     LOG_DOWNLOAD ON
-   )
+)
 
 # Expose required variable (CATCH_INCLUDE_DIR) to parent scope
 ExternalProject_Get_Property(catch source_dir)
-set(CATCH_INCLUDE_DIR ${source_dir}/include CACHE INTERNAL "Path to include folder for Catch")
+set(CATCH_INCLUDE_DIR ${source_dir}/single_include CACHE INTERNAL "Path to include folder for Catch")

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(
 
 add_dependencies(cpp-sort-testsuite catch)
 target_compile_definitions(cpp-sort-testsuite PRIVATE CATCH_CONFIG_FAST_COMPILE)
+target_compile_definitions(cpp-sort-testsuite PRIVATE CATCH_CONFIG_DISABLE_MATCHERS)
 
 string(RANDOM LENGTH 5 ALPHABET 0123456789 RNG_SEED)
 if (${USE_VALGRIND})

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -123,6 +123,7 @@ add_executable(
 )
 
 add_dependencies(cpp-sort-testsuite catch)
+target_compile_definitions(cpp-sort-testsuite PRIVATE CATCH_CONFIG_FAST_COMPILE)
 
 add_test(testsuite cpp-sort-testsuite)
 

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -125,7 +125,11 @@ add_executable(
 add_dependencies(cpp-sort-testsuite catch)
 target_compile_definitions(cpp-sort-testsuite PRIVATE CATCH_CONFIG_FAST_COMPILE)
 
-add_test(testsuite cpp-sort-testsuite)
+string(RANDOM LENGTH 5 ALPHABET 0123456789 RNG_SEED)
+if (${USE_VALGRIND})
+    add_test(NAME testsuite COMMAND valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $<TARGET_FILE:cpp-sort-testsuite> --rng-seed ${RNG_SEED})
+else()
+    add_test(NAME testsuite COMMAND $<TARGET_FILE:cpp-sort-testsuite> --rng-seed ${RNG_SEED})
+endif()
 
-# Enable unit-testing
-enable_testing(true)
+enable_testing()


### PR DESCRIPTION
Apply the following modifications to improve speed of CI:
* Enable apt cache and ccache
* Build with two jobs
* Compile with `CATCH_CONFIG_FAST_COMPILE`
* Link with gold linker

Apply the following other modifications:
* Explicitly build with Catch 1.x
* Reenable asan with GCC on Linux