### PR TITLE
quick_merge_sorter & related improvements

### DIFF
--- a/include/cpp-sort/detail/config.h
+++ b/include/cpp-sort/detail/config.h
@@ -65,4 +65,19 @@
 #   define CPPSORT_ASSUME(cond)
 #endif
 
+////////////////////////////////////////////////////////////
+// CPPSORT_UNREACHABLE
+
+// Mostly useful to silence compiler warnings in the default
+// clause of a switch when we know the default can never be
+// reached
+
+#if defined(__GNUC__) || defined(__clang__)
+#   define CPPSORT_UNREACHABLE __builtin_unreachable()
+#elif defined(_MSC_VER)
+#   define CPPSORT_UNREACHABLE __assume(false)
+#else
+#   define CPPSORT_UNREACHABLE
+#endif
+
 #endif // CPPSORT_DETAIL_CONFIG_H_

--- a/include/cpp-sort/detail/introselect.h
+++ b/include/cpp-sort/detail/introselect.h
@@ -31,6 +31,7 @@
 #include <utility>
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/iter_move.h>
+#include "bitops.h"
 #include "bubble_sort.h"
 #include "config.h"
 #include "insertion_sort.h"

--- a/include/cpp-sort/detail/introselect.h
+++ b/include/cpp-sort/detail/introselect.h
@@ -1,0 +1,344 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_DETAIL_INTROSELECT_H_
+#define CPPSORT_DETAIL_INTROSELECT_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <iterator>
+#include <utility>
+#include <cpp-sort/utility/as_function.h>
+#include <cpp-sort/utility/iter_move.h>
+#include "bubble_sort.h"
+#include "config.h"
+#include "insertion_sort.h"
+#include "iter_sort3.h"
+#include "iterator_traits.h"
+#include "partition.h"
+#include "swap_if.h"
+
+namespace cppsort
+{
+namespace detail
+{
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto small_sort(ForwardIterator first, ForwardIterator,
+                    difference_type_t<ForwardIterator> size,
+                    Compare compare, Projection projection,
+                    std::forward_iterator_tag)
+        -> void
+    {
+        // TODO: find something better than bubble sort
+        bubble_sort(std::move(first), size,
+                    std::move(compare), std::move(projection));
+    }
+
+    template<typename BidirectionalIterator, typename Compare, typename Projection>
+    auto small_sort(BidirectionalIterator first, BidirectionalIterator last,
+                    difference_type_t<BidirectionalIterator>,
+                    Compare compare, Projection projection,
+                    std::bidirectional_iterator_tag)
+        -> void
+    {
+        insertion_sort(std::move(first), std::move(last),
+                       std::move(compare), std::move(projection));
+    }
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto small_sort(ForwardIterator first, ForwardIterator last,
+                    difference_type_t<ForwardIterator> size,
+                    Compare compare, Projection projection)
+        -> void
+    {
+        using category = iterator_category_t<ForwardIterator>;
+        small_sort(first, last, size, std::move(compare), std::move(projection),
+                   category{});
+    }
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto iter_median_5(ForwardIterator it1, ForwardIterator it2, ForwardIterator it3,
+                       ForwardIterator it4, ForwardIterator it5,
+                       Compare compare, Projection projection)
+        -> ForwardIterator
+    {
+        // Median of 5, adapted from https://stackoverflow.com/a/481398/1364752
+
+        using utility::iter_swap;
+
+        auto&& comp = utility::as_function(compare);
+        auto&& proj = utility::as_function(projection);
+
+        iter_swap_if(it1, it2, compare, projection);
+        iter_swap_if(it3, it4, compare, projection);
+
+        if (comp(proj(*it1), proj(*it3))) {
+            iter_swap(it1, it5);
+            iter_swap_if(it1, it2, compare, projection);
+        } else {
+            iter_swap(it3, it5);
+            iter_swap_if(it3, it4, compare, projection);
+        }
+
+        if (comp(proj(*it1), proj(*it3))) {
+            if (comp(proj(*it2), proj(*it3))) {
+                return it3;
+            }
+            return it2;
+        } else {
+            if (comp(proj(*it4), proj(*it1))) {
+                return it1;
+            }
+            return it4;
+        }
+    }
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto iter_median_rest(ForwardIterator first, difference_type_t<ForwardIterator> size,
+                          Compare compare, Projection projection)
+        -> ForwardIterator
+    {
+        using utility::iter_swap;
+
+        switch (size) {
+            case 0:
+            case 1:
+            case 2:
+                return first;
+            case 3: {
+                auto it1 = first;
+                auto it2 = ++first;
+                auto it3 = ++first;
+                iter_swap_if(it1, it2, compare, projection);
+                iter_swap_if(it2, it3, compare, projection);
+                iter_swap_if(it1, it2, compare, projection);
+                return it2;
+            }
+            case 4: {
+                auto it1 = first;
+                auto it2 = ++first;
+                auto it3 = ++first;
+                auto it4 = ++first;
+                iter_swap_if(it1, it2, compare, projection);
+                iter_swap_if(it3, it4, compare, projection);
+                iter_swap_if(it1, it3, compare, projection);
+                iter_swap_if(it2, it4, compare, projection);
+                iter_swap_if(it2, it3, compare, projection);
+                return it2;
+            }
+            case 5: {
+                auto it1 = first;
+                auto it2 = ++first;
+                auto it3 = ++first;
+                auto it4 = ++first;
+                auto it5 = ++first;
+                return iter_median_5(it1, it2, it3, it4, it5,
+                                     std::move(compare), std::move(projection));
+            }
+            default:
+                CPPSORT_UNREACHABLE;
+        }
+    }
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto introselect(ForwardIterator first, ForwardIterator last,
+                     difference_type_t<ForwardIterator> nth_pos,
+                     difference_type_t<ForwardIterator> size, int bad_allowed,
+                     Compare compare, Projection projection)
+        -> ForwardIterator;
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto median_of_medians(ForwardIterator first, ForwardIterator last,
+                           difference_type_t<ForwardIterator> size,
+                           Compare compare, Projection projection)
+        -> ForwardIterator
+    {
+        using utility::iter_swap;
+
+        if (size <= 5) {
+            return iter_median_rest(first, size, std::move(compare), std::move(projection));
+        }
+
+        // Iterator over the collection
+        auto it = first;
+        // Points to the next value to replace by a median-of-5
+        auto medians_it = first;
+
+        // We handle first the biggest part that can be rounded to a power
+        // of 5, then we handle the rest
+        auto rounded_size = (size / 5) * 5;
+
+        // Handle elements 5 by 5
+        for (difference_type_t<ForwardIterator> i = 0 ; i < rounded_size / 5 ; ++i) {
+            auto it1 = it;
+            auto it2 = ++it;
+            auto it3 = ++it;
+            auto it4 = ++it;
+            auto it5 = ++it;
+
+            auto median = iter_median_5(it1, it2, it3, it4, it5, compare, projection);
+            iter_swap(medians_it, median);
+            ++medians_it;
+            ++it;
+        }
+
+        // Handle remaining elements
+        if (rounded_size != size) {
+            auto last_median = iter_median_rest(it, size - rounded_size, compare, projection);
+            iter_swap(last_median, medians_it);
+            ++medians_it;
+        }
+
+        // Rest variables for the next iteration
+        last = medians_it;
+        size = rounded_size == size ? size / 5 : size / 5 + 1;
+
+        // Mutual recursion with introselect
+        return introselect(first, last, size / 2, size, detail::log2(size),
+                           std::move(compare), std::move(projection));
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Get iterator to last element
+
+    template<typename Iterator>
+    auto last_it(Iterator first, Iterator, difference_type_t<Iterator> size,
+                 std::forward_iterator_tag)
+        -> Iterator
+    {
+        return std::next(first, size - 1);
+    }
+
+    template<typename Iterator>
+    auto last_it(Iterator, Iterator last, difference_type_t<Iterator>,
+                 std::bidirectional_iterator_tag)
+        -> Iterator
+    {
+        return std::prev(last);
+    }
+
+    template<typename Iterator>
+    auto last_it(Iterator first, Iterator last, difference_type_t<Iterator> size)
+        -> Iterator
+    {
+        using category = iterator_category_t<Iterator>;
+        return last_it(first, last, size, category{});
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Pick a pivot for quicksort and quickselect
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto pick_pivot(ForwardIterator first, ForwardIterator last,
+                    difference_type_t<ForwardIterator> size, int bad_allowed,
+                    Compare compare, Projection projection)
+        -> std::pair<ForwardIterator, ForwardIterator>
+    {
+        if (bad_allowed > 0) {
+            auto it1 = std::next(first, size / 8);
+            auto it2 = std::next(it1, size / 8);
+            auto it3 = std::next(it2, size / 8);
+            auto middle = std::next(it3, size/2 - 3*(size/8));
+            auto it4 = std::next(middle, size / 8);
+            auto it5 = std::next(it4, size / 8);
+            auto it6 = std::next(it5, size / 8);
+            auto last_1 = last_it(it6, last, size - size/2 - 3*(size/8));
+
+            iter_sort3(first, it1, it2, compare, projection);
+            iter_sort3(it3, middle, it4, compare, projection);
+            iter_sort3(it5, it6, last_1, compare, projection);
+            auto median_it = iter_sort3(it1, middle, it4, std::move(compare), std::move(projection));
+            return std::make_pair(median_it, last_1);
+        } else {
+            auto last_1 = last_it(first, last, size);
+            auto median_it = median_of_medians(first, last, size, compare, projection);
+            return std::make_pair(median_it, last_1);
+        }
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Forward nth_element based on introselect
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto introselect(ForwardIterator first, ForwardIterator last,
+                     difference_type_t<ForwardIterator> nth_pos,
+                     difference_type_t<ForwardIterator> size, int bad_allowed,
+                     Compare compare, Projection projection)
+        -> ForwardIterator
+    {
+        using utility::iter_swap;
+
+        auto&& comp = utility::as_function(compare);
+        auto&& proj = utility::as_function(projection);
+
+        if (size <= 32) {
+            small_sort(first, last, size, std::move(compare), std::move(projection));
+            return std::next(first, nth_pos);
+        }
+
+        // Choose pivot as either median of 9 or median of medians
+        auto temp = pick_pivot(first, last, size, bad_allowed, compare, projection);
+        auto median_it = temp.first;
+        auto last_1 = temp.second;
+
+        // Put the pivot at position std::prev(last) and partition
+        iter_swap(median_it, last_1);
+        auto&& pivot1 = proj(*last_1);
+        auto middle1 = detail::partition(
+            first, last_1,
+            [&](const auto& elem) { return comp(proj(elem), pivot1); }
+        );
+
+        // Put the pivot in its final position and partition
+        iter_swap(middle1, last_1);
+        auto&& pivot2 = proj(*middle1);
+        auto middle2 = detail::partition(
+            std::next(middle1), last,
+            [&](const auto& elem) { return not comp(pivot2, proj(elem)); }
+        );
+
+        // Recursive call: heuristic trick here: in real world cases,
+        // the middle partition is more likely to be smaller than the
+        // right one, so computing its size should generally be cheaper
+        auto size_left = std::distance(first, middle1);
+        auto size_middle = std::distance(middle1, middle2);
+        auto size_right = size - size_left - size_middle;
+
+        // TODO: unroll tail recursion
+        // We're done if the nth element is in the middle partition
+        if (nth_pos < size_left) {
+            return introselect(first, middle1, nth_pos,
+                               size_left, --bad_allowed,
+                               std::move(compare), std::move(projection));
+        } else if (nth_pos > size_left + size_middle) {
+            return introselect(middle2, last, nth_pos - size_left - size_middle,
+                               size_right, --bad_allowed,
+                               std::move(compare), std::move(projection));
+        }
+        // Return an iterator to the nth element
+        return std::next(middle1, nth_pos - size_left);
+    }
+}}
+
+#endif // CPPSORT_DETAIL_INTROSELECT_H_

--- a/include/cpp-sort/detail/iter_sort3.h
+++ b/include/cpp-sort/detail/iter_sort3.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2017 Morwenn
+ * Copyright (c) 2015-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,11 +37,12 @@ namespace detail
     template<typename Iterator, typename Compare, typename Projection>
     auto iter_sort3(Iterator a, Iterator b, Iterator c,
                     Compare compare, Projection projection)
-        -> void
+        -> Iterator
     {
         iter_swap_if(b, c, compare, projection);
         iter_swap_if(a, c, compare, projection);
         iter_swap_if(a, b, std::move(compare), std::move(projection));
+        return b; // Return median
     }
 }}
 

--- a/include/cpp-sort/detail/iter_sort3.h
+++ b/include/cpp-sort/detail/iter_sort3.h
@@ -42,7 +42,7 @@ namespace detail
         iter_swap_if(b, c, compare, projection);
         iter_swap_if(a, c, compare, projection);
         iter_swap_if(a, b, std::move(compare), std::move(projection));
-        return b; // Return median
+        return b; // Return median of 3
     }
 }}
 

--- a/include/cpp-sort/detail/nth_element.h
+++ b/include/cpp-sort/detail/nth_element.h
@@ -41,6 +41,9 @@
 #include <utility>
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/iter_move.h>
+#include "bubble_sort.h"
+#include "config.h"
+#include "insertion_sort.h"
 #include "iterator_traits.h"
 #include "partition.h"
 #include "selection_sort.h"
@@ -50,6 +53,40 @@ namespace cppsort
 {
 namespace detail
 {
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto small_sort(ForwardIterator first, ForwardIterator,
+                    difference_type_t<ForwardIterator> size,
+                    Compare compare, Projection projection,
+                    std::forward_iterator_tag)
+        -> void
+    {
+        // TODO: find something better than bubble sort
+        bubble_sort(std::move(first), size,
+                    std::move(compare), std::move(projection));
+    }
+
+    template<typename BidirectionalIterator, typename Compare, typename Projection>
+    auto small_sort(BidirectionalIterator first, BidirectionalIterator last,
+                    difference_type_t<BidirectionalIterator>,
+                    Compare compare, Projection projection,
+                    std::bidirectional_iterator_tag)
+        -> void
+    {
+        insertion_sort(std::move(first), std::move(last),
+                       std::move(compare), std::move(projection));
+    }
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto small_sort(ForwardIterator first, ForwardIterator last,
+                    difference_type_t<ForwardIterator> size,
+                    Compare compare, Projection projection)
+        -> void
+    {
+        using category = iterator_category_t<ForwardIterator>;
+        small_sort(first, last, size, std::move(compare), std::move(projection),
+                   category{});
+    }
+
     template<typename ForwardIterator, typename Compare, typename Projection>
     auto sort3(ForwardIterator x, ForwardIterator y, ForwardIterator z,
                Compare compare, Projection projection)
@@ -171,7 +208,7 @@ namespace detail
                                      std::move(compare), std::move(projection));
             }
             default:
-                __builtin_unreachable();  // TODO: something more generic
+                CPPSORT_UNREACHABLE;
         }
     }
 
@@ -190,49 +227,76 @@ namespace detail
     {
         using utility::iter_swap;
 
-        // TODO: mutual recursion with introselect instead
-
-        while (size > 5) {
-
-            assert(std::distance(first, last) == size);
-
-            // Iterator over the collection
-            auto it = first;
-            // Points to the next value to replace by a median-of-5
-            auto medians_it = first;
-
-            // We handle first the biggest part that can be rounded to a power
-            // of 5, then we handle the rest
-            auto rounded_size = (size / 5) * 5;
-
-            // Handle elements 5 by 5
-            for (difference_type_t<ForwardIterator> i = 0 ; i < rounded_size / 5 ; ++i) {
-                auto it1 = it;
-                auto it2 = ++it;
-                auto it3 = ++it;
-                auto it4 = ++it;
-                auto it5 = ++it;
-
-                auto median = iter_median_5(it1, it2, it3, it4, it5, compare, projection);
-                iter_swap(medians_it, median);
-                ++medians_it;
-                ++it;
-            }
-
-            // Handle remaining elements
-            if (rounded_size != size) {
-                auto last_median = iter_median_rest(it, size - rounded_size, compare, projection);
-                iter_swap(last_median, medians_it);
-                ++medians_it;
-            }
-
-            // Rest variables for the next iteration
-            last = medians_it;
-            size = rounded_size == size ? size / 5 : size / 5 + 1;
+        if (size <= 5) {
+            return iter_median_rest(first, size, std::move(compare), std::move(projection));
         }
 
-        // There are at most 5 elements, return the median of those
-        return iter_median_rest(first, size, std::move(compare), std::move(projection));
+        // Iterator over the collection
+        auto it = first;
+        // Points to the next value to replace by a median-of-5
+        auto medians_it = first;
+
+        // We handle first the biggest part that can be rounded to a power
+        // of 5, then we handle the rest
+        auto rounded_size = (size / 5) * 5;
+
+        // Handle elements 5 by 5
+        for (difference_type_t<ForwardIterator> i = 0 ; i < rounded_size / 5 ; ++i) {
+            auto it1 = it;
+            auto it2 = ++it;
+            auto it3 = ++it;
+            auto it4 = ++it;
+            auto it5 = ++it;
+
+            auto median = iter_median_5(it1, it2, it3, it4, it5, compare, projection);
+            iter_swap(medians_it, median);
+            ++medians_it;
+            ++it;
+        }
+
+        // Handle remaining elements
+        if (rounded_size != size) {
+            auto last_median = iter_median_rest(it, size - rounded_size, compare, projection);
+            iter_swap(last_median, medians_it);
+            ++medians_it;
+        }
+
+        // Rest variables for the next iteration
+        last = medians_it;
+        size = rounded_size == size ? size / 5 : size / 5 + 1;
+
+        // Mutual recursion with introselect
+        return introselect(first, last, size / 2, size, detail::log2(size),
+                           std::move(compare), std::move(projection));
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Get iterator to last element
+
+    template<typename Iterator>
+    auto last_it(Iterator first, Iterator,
+                 difference_type_t<Iterator> size,
+                 std::forward_iterator_tag)
+        -> Iterator
+    {
+        return std::next(first, size - 1);
+    }
+
+    template<typename Iterator>
+    auto last_it(Iterator, Iterator last,
+                 difference_type_t<Iterator>,
+                 std::bidirectional_iterator_tag)
+        -> Iterator
+    {
+        return std::prev(last);
+    }
+
+    template<typename Iterator>
+    auto last_it(Iterator first, Iterator last, difference_type_t<Iterator> size)
+        -> Iterator
+    {
+        using category = iterator_category_t<Iterator>;
+        return last_it(first, last, size, category{});
     }
 
     ////////////////////////////////////////////////////////////
@@ -251,28 +315,44 @@ namespace detail
         auto&& proj = utility::as_function(projection);
 
         if (size <= 32) {
-            insertion_sort(first, last, std::move(compare), std::move(projection));
+            small_sort(first, last, size, std::move(compare), std::move(projection));
             return std::next(first, nth_pos);
         }
 
-        // Choose pivot as either median of 3 or median of medians
-        auto middle = std::next(first, size / 2);
-        auto last_1 = std::next(middle, size - size/2 - 1);
+        // Choose pivot as either median of 9 or median of medians
+        auto temp = [&] {
+            if (bad_allowed > 0) {
+                auto it1 = std::next(first, size / 8);
+                auto it2 = std::next(it1, size / 8);
+                auto it3 = std::next(it2, size / 8);
+                auto middle = std::next(it3, size/2 - 3*(size/8));
+                auto it4 = std::next(middle, size / 8);
+                auto it5 = std::next(it4, size / 8);
+                auto it6 = std::next(it5, size / 8);
+                auto last_1 = last_it(it6, last, size - size/2 - 3*(size/8) - 1);
 
-        auto median_it = (bad_allowed != 0) ?
-            iter_sort3(first, middle, last_1, compare, projection) :
-            median_of_medians(first, last, size, compare, projection);
+                iter_sort3(first, it1, it2, compare, projection);
+                iter_sort3(it3, middle, it4, compare, projection);
+                iter_sort3(it5, it6, last_1, compare, projection);
+                auto median_it = iter_sort3(it1, middle, it4, std::move(compare), std::move(projection));
+                return std::make_pair(median_it, last_1);
+            } else {
+                auto last_1 = last_it(first, last, size);
+                auto median_it = median_of_medians(first, last, size, compare, projection);
+                return std::make_pair(median_it, last_1);
+            }
+        }();
 
         // Put the pivot at position std::prev(last) and partition
-        iter_swap(median_it, last_1);
-        auto&& pivot1 = proj(*last_1);
+        iter_swap(temp.first, temp.second);
+        auto&& pivot1 = proj(*temp.second);
         auto middle1 = detail::partition(
-            first, last_1,
+            first, temp.second,
             [&](const auto& elem) { return comp(proj(elem), pivot1); }
         );
 
         // Put the pivot in its final position and partition
-        iter_swap(middle1, last_1);
+        iter_swap(middle1, temp.second);
         auto&& pivot2 = proj(*middle1);
         auto middle2 = detail::partition(
             std::next(middle1), last,
@@ -289,13 +369,13 @@ namespace detail
         // TODO: unroll tail recursion
         // We're done if the nth element is in the middle partition
         if (nth_pos < size_left) {
-            introselect(first, middle1, nth_pos,
-                        size_left, --bad_allowed,
-                        std::move(compare), std::move(projection));
+            return introselect(first, middle1, nth_pos,
+                               size_left, --bad_allowed,
+                               std::move(compare), std::move(projection));
         } else if (nth_pos > size_left + size_middle) {
-            introselect(middle2, last, nth_pos - size_left - size_middle,
-                        size_right, --bad_allowed,
-                        std::move(compare), std::move(projection));
+            return introselect(middle2, last, nth_pos - size_left - size_middle,
+                               size_right, --bad_allowed,
+                               std::move(compare), std::move(projection));
         }
         // Return an iterator to the nth element
         return std::next(middle1, nth_pos - size_left);

--- a/include/cpp-sort/detail/nth_element.h
+++ b/include/cpp-sort/detail/nth_element.h
@@ -1,26 +1,3 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2018 Morwenn
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
 //===----------------------------------------------------------------------===//
 //
 //                     The LLVM Compiler Infrastructure
@@ -41,51 +18,31 @@
 #include <utility>
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/iter_move.h>
-#include "bubble_sort.h"
-#include "config.h"
-#include "insertion_sort.h"
+#include "introselect.h"
 #include "iterator_traits.h"
-#include "partition.h"
 #include "selection_sort.h"
-#include "swap_if.h"
 
 namespace cppsort
 {
 namespace detail
 {
-    template<typename ForwardIterator, typename Compare, typename Projection>
-    auto small_sort(ForwardIterator first, ForwardIterator,
-                    difference_type_t<ForwardIterator> size,
-                    Compare compare, Projection projection,
-                    std::forward_iterator_tag)
-        -> void
-    {
-        // TODO: find something better than bubble sort
-        bubble_sort(std::move(first), size,
-                    std::move(compare), std::move(projection));
-    }
-
-    template<typename BidirectionalIterator, typename Compare, typename Projection>
-    auto small_sort(BidirectionalIterator first, BidirectionalIterator last,
-                    difference_type_t<BidirectionalIterator>,
-                    Compare compare, Projection projection,
-                    std::bidirectional_iterator_tag)
-        -> void
-    {
-        insertion_sort(std::move(first), std::move(last),
-                       std::move(compare), std::move(projection));
-    }
+    ////////////////////////////////////////////////////////////
+    // nth_element for forward iterators with introselect
 
     template<typename ForwardIterator, typename Compare, typename Projection>
-    auto small_sort(ForwardIterator first, ForwardIterator last,
-                    difference_type_t<ForwardIterator> size,
-                    Compare compare, Projection projection)
-        -> void
+    auto nth_element(ForwardIterator first, ForwardIterator last,
+                     difference_type_t<ForwardIterator> nth_pos,
+                     difference_type_t<ForwardIterator> size,
+                     Compare compare, Projection projection,
+                     std::forward_iterator_tag)
+        -> ForwardIterator
     {
-        using category = iterator_category_t<ForwardIterator>;
-        small_sort(first, last, size, std::move(compare), std::move(projection),
-                   category{});
+        return introselect(first, last, nth_pos, size, detail::log2(size),
+                           std::move(compare), std::move(projection));
     }
+
+    ////////////////////////////////////////////////////////////
+    // nth_element for random-access iterators from libc++
 
     template<typename ForwardIterator, typename Compare, typename Projection>
     auto sort3(ForwardIterator x, ForwardIterator y, ForwardIterator z,
@@ -127,274 +84,6 @@ namespace detail
         }
         return r;
     } // x <= y && y <= z
-
-    template<typename ForwardIterator, typename Compare, typename Projection>
-    auto iter_median_5(ForwardIterator it1, ForwardIterator it2, ForwardIterator it3,
-                       ForwardIterator it4, ForwardIterator it5,
-                       Compare compare, Projection projection)
-        -> ForwardIterator
-    {
-        // Median of 5, adapted from https://stackoverflow.com/a/481398/1364752
-
-        using utility::iter_swap;
-
-        auto&& comp = utility::as_function(compare);
-        auto&& proj = utility::as_function(projection);
-
-        iter_swap_if(it1, it2, compare, projection);
-        iter_swap_if(it3, it4, compare, projection);
-
-        if (comp(proj(*it1), proj(*it3))) {
-            iter_swap(it1, it5);
-            iter_swap_if(it1, it2, compare, projection);
-        } else {
-            iter_swap(it3, it5);
-            iter_swap_if(it3, it4, compare, projection);
-        }
-
-        if (comp(proj(*it1), proj(*it3))) {
-            if (comp(proj(*it2), proj(*it3))) {
-                return it3;
-            }
-            return it2;
-        } else {
-            if (comp(proj(*it4), proj(*it1))) {
-                return it1;
-            }
-            return it4;
-        }
-    }
-
-    template<typename ForwardIterator, typename Compare, typename Projection>
-    auto iter_median_rest(ForwardIterator first, difference_type_t<ForwardIterator> size,
-                          Compare compare, Projection projection)
-        -> ForwardIterator
-    {
-        using utility::iter_swap;
-
-        switch (size) {
-            case 0:
-            case 1:
-            case 2:
-                return first;
-            case 3: {
-                auto it1 = first;
-                auto it2 = ++first;
-                auto it3 = ++first;
-                iter_swap_if(it1, it2, compare, projection);
-                iter_swap_if(it2, it3, compare, projection);
-                iter_swap_if(it1, it2, compare, projection);
-                return it2;
-            }
-            case 4: {
-                auto it1 = first;
-                auto it2 = ++first;
-                auto it3 = ++first;
-                auto it4 = ++first;
-                iter_swap_if(it1, it2, compare, projection);
-                iter_swap_if(it3, it4, compare, projection);
-                iter_swap_if(it1, it3, compare, projection);
-                iter_swap_if(it2, it4, compare, projection);
-                iter_swap_if(it2, it3, compare, projection);
-                return it2;
-            }
-            case 5: {
-                auto it1 = first;
-                auto it2 = ++first;
-                auto it3 = ++first;
-                auto it4 = ++first;
-                auto it5 = ++first;
-                return iter_median_5(it1, it2, it3, it4, it5,
-                                     std::move(compare), std::move(projection));
-            }
-            default:
-                CPPSORT_UNREACHABLE;
-        }
-    }
-
-    template<typename ForwardIterator, typename Compare, typename Projection>
-    auto introselect(ForwardIterator first, ForwardIterator last,
-                     difference_type_t<ForwardIterator> nth_pos,
-                     difference_type_t<ForwardIterator> size, int bad_allowed,
-                     Compare compare, Projection projection)
-        -> ForwardIterator;
-
-    template<typename ForwardIterator, typename Compare, typename Projection>
-    auto median_of_medians(ForwardIterator first, ForwardIterator last,
-                           difference_type_t<ForwardIterator> size,
-                           Compare compare, Projection projection)
-        -> ForwardIterator
-    {
-        using utility::iter_swap;
-
-        if (size <= 5) {
-            return iter_median_rest(first, size, std::move(compare), std::move(projection));
-        }
-
-        // Iterator over the collection
-        auto it = first;
-        // Points to the next value to replace by a median-of-5
-        auto medians_it = first;
-
-        // We handle first the biggest part that can be rounded to a power
-        // of 5, then we handle the rest
-        auto rounded_size = (size / 5) * 5;
-
-        // Handle elements 5 by 5
-        for (difference_type_t<ForwardIterator> i = 0 ; i < rounded_size / 5 ; ++i) {
-            auto it1 = it;
-            auto it2 = ++it;
-            auto it3 = ++it;
-            auto it4 = ++it;
-            auto it5 = ++it;
-
-            auto median = iter_median_5(it1, it2, it3, it4, it5, compare, projection);
-            iter_swap(medians_it, median);
-            ++medians_it;
-            ++it;
-        }
-
-        // Handle remaining elements
-        if (rounded_size != size) {
-            auto last_median = iter_median_rest(it, size - rounded_size, compare, projection);
-            iter_swap(last_median, medians_it);
-            ++medians_it;
-        }
-
-        // Rest variables for the next iteration
-        last = medians_it;
-        size = rounded_size == size ? size / 5 : size / 5 + 1;
-
-        // Mutual recursion with introselect
-        return introselect(first, last, size / 2, size, detail::log2(size),
-                           std::move(compare), std::move(projection));
-    }
-
-    ////////////////////////////////////////////////////////////
-    // Get iterator to last element
-
-    template<typename Iterator>
-    auto last_it(Iterator first, Iterator,
-                 difference_type_t<Iterator> size,
-                 std::forward_iterator_tag)
-        -> Iterator
-    {
-        return std::next(first, size - 1);
-    }
-
-    template<typename Iterator>
-    auto last_it(Iterator, Iterator last,
-                 difference_type_t<Iterator>,
-                 std::bidirectional_iterator_tag)
-        -> Iterator
-    {
-        return std::prev(last);
-    }
-
-    template<typename Iterator>
-    auto last_it(Iterator first, Iterator last, difference_type_t<Iterator> size)
-        -> Iterator
-    {
-        using category = iterator_category_t<Iterator>;
-        return last_it(first, last, size, category{});
-    }
-
-    ////////////////////////////////////////////////////////////
-    // Forward nth_element based on introselect
-
-    template<typename ForwardIterator, typename Compare, typename Projection>
-    auto introselect(ForwardIterator first, ForwardIterator last,
-                     difference_type_t<ForwardIterator> nth_pos,
-                     difference_type_t<ForwardIterator> size, int bad_allowed,
-                     Compare compare, Projection projection)
-        -> ForwardIterator
-    {
-        using utility::iter_swap;
-
-        auto&& comp = utility::as_function(compare);
-        auto&& proj = utility::as_function(projection);
-
-        if (size <= 32) {
-            small_sort(first, last, size, std::move(compare), std::move(projection));
-            return std::next(first, nth_pos);
-        }
-
-        // Choose pivot as either median of 9 or median of medians
-        auto temp = [&] {
-            if (bad_allowed > 0) {
-                auto it1 = std::next(first, size / 8);
-                auto it2 = std::next(it1, size / 8);
-                auto it3 = std::next(it2, size / 8);
-                auto middle = std::next(it3, size/2 - 3*(size/8));
-                auto it4 = std::next(middle, size / 8);
-                auto it5 = std::next(it4, size / 8);
-                auto it6 = std::next(it5, size / 8);
-                auto last_1 = last_it(it6, last, size - size/2 - 3*(size/8));
-
-                iter_sort3(first, it1, it2, compare, projection);
-                iter_sort3(it3, middle, it4, compare, projection);
-                iter_sort3(it5, it6, last_1, compare, projection);
-                auto median_it = iter_sort3(it1, middle, it4, std::move(compare), std::move(projection));
-                return std::make_pair(median_it, last_1);
-            } else {
-                auto last_1 = last_it(first, last, size);
-                auto median_it = median_of_medians(first, last, size, compare, projection);
-                return std::make_pair(median_it, last_1);
-            }
-        }();
-
-        // Put the pivot at position std::prev(last) and partition
-        iter_swap(temp.first, temp.second);
-        auto&& pivot1 = proj(*temp.second);
-        auto middle1 = detail::partition(
-            first, temp.second,
-            [&](const auto& elem) { return comp(proj(elem), pivot1); }
-        );
-
-        // Put the pivot in its final position and partition
-        iter_swap(middle1, temp.second);
-        auto&& pivot2 = proj(*middle1);
-        auto middle2 = detail::partition(
-            std::next(middle1), last,
-            [&](const auto& elem) { return not comp(pivot2, proj(elem)); }
-        );
-
-        // Recursive call: heuristic trick here: in real world cases,
-        // the middle partition is more likely to be smaller than the
-        // right one, so computing its size should generally be cheaper
-        auto size_left = std::distance(first, middle1);
-        auto size_middle = std::distance(middle1, middle2);
-        auto size_right = size - size_left - size_middle;
-
-        // TODO: unroll tail recursion
-        // We're done if the nth element is in the middle partition
-        if (nth_pos < size_left) {
-            return introselect(first, middle1, nth_pos,
-                               size_left, --bad_allowed,
-                               std::move(compare), std::move(projection));
-        } else if (nth_pos > size_left + size_middle) {
-            return introselect(middle2, last, nth_pos - size_left - size_middle,
-                               size_right, --bad_allowed,
-                               std::move(compare), std::move(projection));
-        }
-        // Return an iterator to the nth element
-        return std::next(middle1, nth_pos - size_left);
-    }
-
-    template<typename ForwardIterator, typename Compare, typename Projection>
-    auto nth_element(ForwardIterator first, ForwardIterator last,
-                     difference_type_t<ForwardIterator> nth_pos,
-                     difference_type_t<ForwardIterator> size,
-                     Compare compare, Projection projection,
-                     std::forward_iterator_tag)
-        -> ForwardIterator
-    {
-        return introselect(first, last, nth_pos, size, detail::log2(size),
-                           std::move(compare), std::move(projection));
-    }
-
-    ////////////////////////////////////////////////////////////
-    // Random-access nth_element from libc++
 
     template<typename RandomAccessIterator, typename Compare, typename Projection>
     auto nth_element(RandomAccessIterator first, RandomAccessIterator last,

--- a/include/cpp-sort/detail/nth_element.h
+++ b/include/cpp-sort/detail/nth_element.h
@@ -329,7 +329,7 @@ namespace detail
                 auto it4 = std::next(middle, size / 8);
                 auto it5 = std::next(it4, size / 8);
                 auto it6 = std::next(it5, size / 8);
-                auto last_1 = last_it(it6, last, size - size/2 - 3*(size/8) - 1);
+                auto last_1 = last_it(it6, last, size - size/2 - 3*(size/8));
 
                 iter_sort3(first, it1, it2, compare, projection);
                 iter_sort3(it3, middle, it4, compare, projection);

--- a/include/cpp-sort/detail/nth_element.h
+++ b/include/cpp-sort/detail/nth_element.h
@@ -1,0 +1,258 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//            Modified in 2018 by Morwenn for inclusion into cpp-sort
+//
+//===----------------------------------------------------------------------===//
+#ifndef CPPSORT_DETAIL_NTH_ELEMENT_H_
+#define CPPSORT_DETAIL_NTH_ELEMENT_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <cpp-sort/utility/as_function.h>
+#include <cpp-sort/utility/iter_move.h>
+#include "selection_sort.h"
+
+namespace cppsort
+{
+namespace detail
+{
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto sort3(ForwardIterator x, ForwardIterator y, ForwardIterator z,
+               Compare compare, Projection projection)
+        -> unsigned
+    {
+        using utility::iter_swap;
+
+        auto&& comp = utility::as_function(compare);
+        auto&& proj = utility::as_function(projection);
+
+        unsigned r = 0;
+        if (not comp(proj(*y), proj(*x)))          // if x <= y
+        {
+            if (not comp(proj(*z), proj(*y)))      // if y <= z
+                return r;                   // x <= y && y <= z
+                                            // x <= y && y > z
+            iter_swap(y, z);                // x <= z && y < z
+            r = 1;
+            if (comp(proj(*y), proj(*x)))   // if x > y
+            {
+                iter_swap(x, y);            // x < y && y <= z
+                r = 2;
+            }
+            return r;                       // x <= y && y < z
+        }
+        if (comp(proj(*z), proj(*y)))       // x > y, if y > z
+        {
+            iter_swap(x, z);                // x < y && y < z
+            r = 1;
+            return r;
+        }
+        iter_swap(x, y);                    // x > y && y <= z
+        r = 1;                              // x < y && x <= z
+        if (comp(proj(*z), proj(*y)))       // if y > z
+        {
+            iter_swap(y, z);                // x <= y && y < z
+            r = 2;
+        }
+        return r;
+    } // x <= y && y <= z
+
+    template<typename RandomAccessIterator, typename Compare, typename Projection>
+    auto nth_element(RandomAccessIterator first, RandomAccessIterator nth, RandomAccessIterator last,
+                     Compare compare, Projection projection)
+        -> void
+    {
+        using utility::iter_swap;
+
+        auto&& comp = utility::as_function(compare);
+        auto&& proj = utility::as_function(projection);
+
+        using difference_type = difference_type_t<RandomAccessIterator>;
+        constexpr difference_type limit = 7;
+
+        while (true)
+        {
+        restart:
+            if (nth == last)
+                return;
+            difference_type len = last - first;
+            switch (len)
+            {
+                case 0:
+                case 1:
+                    return;
+                case 2:
+                    if (comp(proj(*--last), proj(*first))) {
+                        iter_swap(first, last);
+                    }
+                    return;
+                case 3:
+                    RandomAccessIterator m = first;
+                    sort3(first, ++m, --last, std::move(compare), std::move(projection));
+                    return;
+            }
+            if (len <= limit) {
+                selection_sort(first, last, std::move(compare), std::move(projection));
+                return;
+            }
+            // len > limit >= 3
+            RandomAccessIterator m = first + len / 2;
+            RandomAccessIterator lm1 = last;
+            unsigned n_swaps = sort3(first, m, --lm1, compare, projection);
+            // *m is median
+            // partition [first, m) < *m and *m <= [m, last)
+            // (this inhibits tossing elements equivalent to m around unnecessarily)
+            RandomAccessIterator i = first;
+            RandomAccessIterator j = lm1;
+            // j points beyond range to be tested, *lm1 is known to be <= *m
+            // The search going up is known to be guarded but the search coming down isn't.
+            // Prime the downward search with a guard.
+            if (not comp(proj(*i), proj(*m)))  // if *first == *m
+            {
+                // *first == *m, *first doesn't go in first part
+                // manually guard downward moving j against i
+                while (true)
+                {
+                    if (i == --j)
+                    {
+                        // *first == *m, *m <= all other elements
+                        // Parition instead into [first, i) == *first and *first < [i, last)
+                        ++i;  // first + 1
+                        j = last;
+                        if (not comp(proj(*first), proj(*--j)))  // we need a guard if *first == *(last-1)
+                        {
+                            while (true)
+                            {
+                                if (i == j)
+                                    return;  // [first, last) all equivalent elements
+                                if (comp(proj(*first), proj(*i)))
+                                {
+                                    iter_swap(i, j);
+                                    ++n_swaps;
+                                    ++i;
+                                    break;
+                                }
+                                ++i;
+                            }
+                        }
+                        // [first, i) == *first and *first < [j, last) and j == last - 1
+                        if (i == j)
+                            return;
+                        while (true)
+                        {
+                            while (not comp(proj(*first), proj(*i)))
+                                ++i;
+                            while (comp(proj(*first), proj(*--j)))
+                                ;
+                            if (i >= j)
+                                break;
+                            iter_swap(i, j);
+                            ++n_swaps;
+                            ++i;
+                        }
+                        // [first, i) == *first and *first < [i, last)
+                        // The first part is sorted,
+                        if (nth < i)
+                            return;
+                        // nth_element the second part
+                        // nth_element(i, nth, last, comp);
+                        first = i;
+                        goto restart;
+                    }
+                    if (comp(proj(*j), proj(*m)))
+                    {
+                        iter_swap(i, j);
+                        ++n_swaps;
+                        break;  // found guard for downward moving j, now use unguarded partition
+                    }
+                }
+            }
+            ++i;
+            // j points beyond range to be tested, *lm1 is known to be <= *m
+            // if not yet partitioned...
+            if (i < j)
+            {
+                // known that *(i - 1) < *m
+                while (true)
+                {
+                    // m still guards upward moving i
+                    while (comp(proj(*i), proj(*m)))
+                        ++i;
+                    // It is now known that a guard exists for downward moving j
+                    while (not comp(proj(*--j), proj(*m)))
+                        ;
+                    if (i >= j)
+                        break;
+                    iter_swap(i, j);
+                    ++n_swaps;
+                    // It is known that m != j
+                    // If m just moved, follow it
+                    if (m == i)
+                        m = j;
+                    ++i;
+                }
+            }
+            // [first, i) < *m and *m <= [i, last)
+            if (i != m && comp(proj(*m), proj(*i)))
+            {
+                iter_swap(i, m);
+                ++n_swaps;
+            }
+            // [first, i) < *i and *i <= [i+1, last)
+            if (nth == i)
+                return;
+            if (n_swaps == 0)
+            {
+                // We were given a perfectly partitioned sequence.  Coincidence?
+                if (nth < i)
+                {
+                    // Check for [first, i) already sorted
+                    j = m = first;
+                    while (++j != i)
+                    {
+                        if (comp(proj(*j), proj(*m)))
+                            // not yet sorted, so sort
+                            goto not_sorted;
+                        m = j;
+                    }
+                    // [first, i) sorted
+                    return;
+                }
+                else
+                {
+                    // Check for [i, last) already sorted
+                    j = m = i;
+                    while (++j != last)
+                    {
+                        if (comp(proj(*j), proj(*m)))
+                            // not yet sorted, so sort
+                            goto not_sorted;
+                        m = j;
+                    }
+                    // [i, last) sorted
+                    return;
+                }
+            }
+    not_sorted:
+            // nth_element on range containing nth
+            if (nth < i)
+            {
+                // nth_element(first, nth, i, comp);
+                last = i;
+            }
+            else
+            {
+                // nth_element(i+1, nth, last, comp);
+                first = ++i;
+            }
+        }
+    }
+}}
+
+#endif // CPPSORT_DETAIL_NTH_ELEMENT_H_

--- a/include/cpp-sort/detail/nth_element.h
+++ b/include/cpp-sort/detail/nth_element.h
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 //===----------------------------------------------------------------------===//
 //
 //                     The LLVM Compiler Infrastructure
@@ -14,9 +37,14 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <iterator>
+#include <utility>
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/iter_move.h>
+#include "iterator_traits.h"
+#include "partition.h"
 #include "selection_sort.h"
+#include "swap_if.h"
 
 namespace cppsort
 {
@@ -63,10 +91,238 @@ namespace detail
         return r;
     } // x <= y && y <= z
 
-    template<typename RandomAccessIterator, typename Compare, typename Projection>
-    auto nth_element(RandomAccessIterator first, RandomAccessIterator nth, RandomAccessIterator last,
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto iter_median_5(ForwardIterator it1, ForwardIterator it2, ForwardIterator it3,
+                       ForwardIterator it4, ForwardIterator it5,
+                       Compare compare, Projection projection)
+        -> ForwardIterator
+    {
+        // Median of 5, adapted from https://stackoverflow.com/a/481398/1364752
+
+        using utility::iter_swap;
+
+        auto&& comp = utility::as_function(compare);
+        auto&& proj = utility::as_function(projection);
+
+        iter_swap_if(it1, it2, compare, projection);
+        iter_swap_if(it3, it4, compare, projection);
+
+        if (comp(proj(*it1), proj(*it3))) {
+            iter_swap(it1, it5);
+            iter_swap_if(it1, it2, compare, projection);
+        } else {
+            iter_swap(it3, it5);
+            iter_swap_if(it3, it4, compare, projection);
+        }
+
+        if (comp(proj(*it1), proj(*it3))) {
+            if (comp(proj(*it2), proj(*it3))) {
+                return it3;
+            }
+            return it2;
+        } else {
+            if (comp(proj(*it4), proj(*it1))) {
+                return it1;
+            }
+            return it4;
+        }
+    }
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto iter_median_rest(ForwardIterator first, difference_type_t<ForwardIterator> size,
+                          Compare compare, Projection projection)
+        -> ForwardIterator
+    {
+        using utility::iter_swap;
+
+        switch (size) {
+            case 0:
+            case 1:
+            case 2:
+                return first;
+            case 3: {
+                auto it1 = first;
+                auto it2 = ++first;
+                auto it3 = ++first;
+                iter_swap_if(it1, it2, compare, projection);
+                iter_swap_if(it2, it3, compare, projection);
+                iter_swap_if(it1, it2, compare, projection);
+                return it2;
+            }
+            case 4: {
+                auto it1 = first;
+                auto it2 = ++first;
+                auto it3 = ++first;
+                auto it4 = ++first;
+                iter_swap_if(it1, it2, compare, projection);
+                iter_swap_if(it3, it4, compare, projection);
+                iter_swap_if(it1, it3, compare, projection);
+                iter_swap_if(it2, it4, compare, projection);
+                iter_swap_if(it2, it3, compare, projection);
+                return it2;
+            }
+            case 5: {
+                auto it1 = first;
+                auto it2 = ++first;
+                auto it3 = ++first;
+                auto it4 = ++first;
+                auto it5 = ++first;
+                return iter_median_5(it1, it2, it3, it4, it5,
+                                     std::move(compare), std::move(projection));
+            }
+            default:
+                __builtin_unreachable();  // TODO: something more generic
+        }
+    }
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto introselect(ForwardIterator first, ForwardIterator last,
+                     difference_type_t<ForwardIterator> nth_pos,
+                     difference_type_t<ForwardIterator> size, int bad_allowed,
                      Compare compare, Projection projection)
-        -> void
+        -> ForwardIterator;
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto median_of_medians(ForwardIterator first, ForwardIterator last,
+                           difference_type_t<ForwardIterator> size,
+                           Compare compare, Projection projection)
+        -> ForwardIterator
+    {
+        using utility::iter_swap;
+
+        // TODO: mutual recursion with introselect instead
+
+        while (size > 5) {
+
+            assert(std::distance(first, last) == size);
+
+            // Iterator over the collection
+            auto it = first;
+            // Points to the next value to replace by a median-of-5
+            auto medians_it = first;
+
+            // We handle first the biggest part that can be rounded to a power
+            // of 5, then we handle the rest
+            auto rounded_size = (size / 5) * 5;
+
+            // Handle elements 5 by 5
+            for (difference_type_t<ForwardIterator> i = 0 ; i < rounded_size / 5 ; ++i) {
+                auto it1 = it;
+                auto it2 = ++it;
+                auto it3 = ++it;
+                auto it4 = ++it;
+                auto it5 = ++it;
+
+                auto median = iter_median_5(it1, it2, it3, it4, it5, compare, projection);
+                iter_swap(medians_it, median);
+                ++medians_it;
+                ++it;
+            }
+
+            // Handle remaining elements
+            if (rounded_size != size) {
+                auto last_median = iter_median_rest(it, size - rounded_size, compare, projection);
+                iter_swap(last_median, medians_it);
+                ++medians_it;
+            }
+
+            // Rest variables for the next iteration
+            last = medians_it;
+            size = rounded_size == size ? size / 5 : size / 5 + 1;
+        }
+
+        // There are at most 5 elements, return the median of those
+        return iter_median_rest(first, size, std::move(compare), std::move(projection));
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Forward nth_element based on introselect
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto introselect(ForwardIterator first, ForwardIterator last,
+                     difference_type_t<ForwardIterator> nth_pos,
+                     difference_type_t<ForwardIterator> size, int bad_allowed,
+                     Compare compare, Projection projection)
+        -> ForwardIterator
+    {
+        using utility::iter_swap;
+
+        auto&& comp = utility::as_function(compare);
+        auto&& proj = utility::as_function(projection);
+
+        if (size <= 32) {
+            insertion_sort(first, last, std::move(compare), std::move(projection));
+            return std::next(first, nth_pos);
+        }
+
+        // Choose pivot as either median of 3 or median of medians
+        auto middle = std::next(first, size / 2);
+        auto last_1 = std::next(middle, size - size/2 - 1);
+
+        auto median_it = (bad_allowed != 0) ?
+            iter_sort3(first, middle, last_1, compare, projection) :
+            median_of_medians(first, last, size, compare, projection);
+
+        // Put the pivot at position std::prev(last) and partition
+        iter_swap(median_it, last_1);
+        auto&& pivot1 = proj(*last_1);
+        auto middle1 = detail::partition(
+            first, last_1,
+            [&](const auto& elem) { return comp(proj(elem), pivot1); }
+        );
+
+        // Put the pivot in its final position and partition
+        iter_swap(middle1, last_1);
+        auto&& pivot2 = proj(*middle1);
+        auto middle2 = detail::partition(
+            std::next(middle1), last,
+            [&](const auto& elem) { return not comp(pivot2, proj(elem)); }
+        );
+
+        // Recursive call: heuristic trick here: in real world cases,
+        // the middle partition is more likely to be smaller than the
+        // right one, so computing its size should generally be cheaper
+        auto size_left = std::distance(first, middle1);
+        auto size_middle = std::distance(middle1, middle2);
+        auto size_right = size - size_left - size_middle;
+
+        // TODO: unroll tail recursion
+        // We're done if the nth element is in the middle partition
+        if (nth_pos < size_left) {
+            introselect(first, middle1, nth_pos,
+                        size_left, --bad_allowed,
+                        std::move(compare), std::move(projection));
+        } else if (nth_pos > size_left + size_middle) {
+            introselect(middle2, last, nth_pos - size_left - size_middle,
+                        size_right, --bad_allowed,
+                        std::move(compare), std::move(projection));
+        }
+        // Return an iterator to the nth element
+        return std::next(middle1, nth_pos - size_left);
+    }
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto nth_element(ForwardIterator first, ForwardIterator last,
+                     difference_type_t<ForwardIterator> nth_pos,
+                     difference_type_t<ForwardIterator> size,
+                     Compare compare, Projection projection,
+                     std::forward_iterator_tag)
+        -> ForwardIterator
+    {
+        return introselect(first, last, nth_pos, size, detail::log2(size),
+                           std::move(compare), std::move(projection));
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Random-access nth_element from libc++
+
+    template<typename RandomAccessIterator, typename Compare, typename Projection>
+    auto nth_element(RandomAccessIterator first, RandomAccessIterator last,
+                     difference_type_t<RandomAccessIterator> nth_pos,
+                     difference_type_t<RandomAccessIterator>, // unused
+                     Compare compare, Projection projection,
+                     std::random_access_iterator_tag)
+        -> RandomAccessIterator
     {
         using utility::iter_swap;
 
@@ -76,30 +332,32 @@ namespace detail
         using difference_type = difference_type_t<RandomAccessIterator>;
         constexpr difference_type limit = 7;
 
+        auto nth = first + nth_pos;
+
         while (true)
         {
         restart:
             if (nth == last)
-                return;
+                return nth;
             difference_type len = last - first;
             switch (len)
             {
                 case 0:
                 case 1:
-                    return;
+                    return nth;
                 case 2:
                     if (comp(proj(*--last), proj(*first))) {
                         iter_swap(first, last);
                     }
-                    return;
+                    return nth;
                 case 3:
                     RandomAccessIterator m = first;
                     sort3(first, ++m, --last, std::move(compare), std::move(projection));
-                    return;
+                    return nth;
             }
             if (len <= limit) {
                 selection_sort(first, last, std::move(compare), std::move(projection));
-                return;
+                return nth;
             }
             // len > limit >= 3
             RandomAccessIterator m = first + len / 2;
@@ -130,7 +388,7 @@ namespace detail
                             while (true)
                             {
                                 if (i == j)
-                                    return;  // [first, last) all equivalent elements
+                                    return nth;  // [first, last) all equivalent elements
                                 if (comp(proj(*first), proj(*i)))
                                 {
                                     iter_swap(i, j);
@@ -143,7 +401,7 @@ namespace detail
                         }
                         // [first, i) == *first and *first < [j, last) and j == last - 1
                         if (i == j)
-                            return;
+                            return nth;
                         while (true)
                         {
                             while (not comp(proj(*first), proj(*i)))
@@ -159,7 +417,7 @@ namespace detail
                         // [first, i) == *first and *first < [i, last)
                         // The first part is sorted,
                         if (nth < i)
-                            return;
+                            return nth;
                         // nth_element the second part
                         // nth_element(i, nth, last, comp);
                         first = i;
@@ -206,7 +464,7 @@ namespace detail
             }
             // [first, i) < *i and *i <= [i+1, last)
             if (nth == i)
-                return;
+                return nth;
             if (n_swaps == 0)
             {
                 // We were given a perfectly partitioned sequence.  Coincidence?
@@ -222,7 +480,7 @@ namespace detail
                         m = j;
                     }
                     // [first, i) sorted
-                    return;
+                    return nth;
                 }
                 else
                 {
@@ -236,7 +494,7 @@ namespace detail
                         m = j;
                     }
                     // [i, last) sorted
-                    return;
+                    return nth;
                 }
             }
     not_sorted:
@@ -252,6 +510,25 @@ namespace detail
                 first = ++i;
             }
         }
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Generic nth_element overload, slightly modified compared
+    // to the standard library one to avoid recomputing sizes
+    // over and over again, which might be too expensive for
+    // forward and bidirectional iterators
+
+    template<typename ForwardIterator, typename Compare, typename Projection>
+    auto nth_element(ForwardIterator first, ForwardIterator last,
+                     difference_type_t<ForwardIterator> nth_pos,
+                     difference_type_t<ForwardIterator> size,
+                     Compare compare, Projection projection)
+        -> ForwardIterator
+    {
+        using category = iterator_category_t<ForwardIterator>;
+        return detail::nth_element(first, last, nth_pos, size,
+                                   std::move(compare), std::move(projection),
+                                   category{});
     }
 }}
 

--- a/include/cpp-sort/detail/quick_merge_sort.h
+++ b/include/cpp-sort/detail/quick_merge_sort.h
@@ -32,7 +32,6 @@
 #include <cpp-sort/utility/as_function.h>
 #include <cpp-sort/utility/iter_move.h>
 #include "config.h"
-#include "insertion_sort.h"
 #include "nth_element.h"
 #include "quicksort.h"
 #include "swap_ranges.h"
@@ -41,7 +40,7 @@ namespace cppsort
 {
 namespace detail
 {
-    constexpr int qmsort_insertion_limit = 32;
+    constexpr int qmsort_limit = 32;
 
     template<typename InputIterator1, typename InputIterator2, typename OutputIterator,
              typename Size, typename Compare, typename Projection>
@@ -106,8 +105,8 @@ namespace detail
                             Compare compare, Projection projection)
         -> void
     {
-        if (size <= qmsort_insertion_limit) {
-            insertion_sort(first, last, std::move(compare), std::move(projection));
+        if (size <= qmsort_limit) {
+            small_sort(first, last, size, std::move(compare), std::move(projection));
             return;
         }
 
@@ -150,7 +149,7 @@ namespace detail
         // to apply mergesort to the left partition, then QuickMergeSort is
         // recursively applied to the smaller right partition
 
-        while (size > qmsort_insertion_limit) {
+        while (size > qmsort_limit) {
             // This represents both the size of the left partition
             // and the position of the pivot
             auto size_left = 2 * (size / 3) - 2;
@@ -160,7 +159,7 @@ namespace detail
             first = pivot;
             size -= size_left;
         }
-        insertion_sort(first, last, std::move(compare), std::move(projection));
+        small_sort(first, last, size, std::move(compare), std::move(projection));
     }
 }}
 

--- a/include/cpp-sort/detail/quick_merge_sort.h
+++ b/include/cpp-sort/detail/quick_merge_sort.h
@@ -1,0 +1,147 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_DETAIL_QUICK_MERGE_SORT_H_
+#define CPPSORT_DETAIL_QUICK_MERGE_SORT_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <iterator>
+#include <utility>
+#include <cpp-sort/utility/as_function.h>
+#include <cpp-sort/utility/iter_move.h>
+#include "config.h"
+#include "insertion_sort.h"
+#include "nth_element.h"
+#include "swap_ranges.h"
+
+namespace cppsort
+{
+namespace detail
+{
+    constexpr int qmsort_insertion_limit = 32;
+
+    template<typename InputIterator1, typename InputIterator2, typename OutputIterator,
+             typename Size, typename Compare, typename Projection>
+    auto internal_half_inplace_merge(InputIterator1 first1, InputIterator1 last1,
+                                     InputIterator2 first2, InputIterator2 last2,
+                                     OutputIterator result, Size min_len,
+                                     Compare compare, Projection projection)
+        -> void
+    {
+        using utility::iter_swap;
+
+        auto&& comp = utility::as_function(compare);
+        auto&& proj = utility::as_function(projection);
+
+        for (; min_len != 0 ; --min_len) {
+            CPPSORT_ASSUME(first1 != last1);
+            CPPSORT_ASSUME(first2 != last2);
+            if (comp(proj(*first2), proj(*first1))) {
+                iter_swap(result, first2);
+                ++first2;
+            } else {
+                iter_swap(result, first1);
+                ++first1;
+            }
+            ++result;
+        }
+
+        for (; first1 != last1; ++result) {
+            if (first2 == last2) {
+                detail::swap_ranges(first1, last1, result);
+                return;
+            }
+
+            if (comp(proj(*first2), proj(*first1))) {
+                iter_swap(result, first2);
+                ++first2;
+            } else {
+                iter_swap(result, first1);
+                ++first1;
+            }
+        }
+        // first2 through last2 are already in the right place
+    }
+
+    template<typename BidirectionalIterator, typename Compare, typename Projection>
+    auto internal_buffered_inplace_merge(BidirectionalIterator first, BidirectionalIterator middle,
+                                         BidirectionalIterator last, BidirectionalIterator buffer,
+                                         Compare compare, Projection projection)
+        -> void
+    {
+        auto buffer_end = detail::swap_ranges(first, middle, buffer);
+        internal_half_inplace_merge(buffer, buffer_end, middle, last, first,
+                                    std::distance(first, middle),
+                                    std::move(compare), std::move(projection));
+    }
+
+    template<typename BidirectionalIterator, typename Compare, typename Projection>
+    auto internal_mergesort(BidirectionalIterator first, BidirectionalIterator last,
+                            BidirectionalIterator buffer,
+                            Compare compare, Projection projection)
+        -> void
+    {
+        if (std::distance(first, last) <= qmsort_insertion_limit) {
+            insertion_sort(first, last, std::move(compare), std::move(projection));
+            return;
+        }
+
+        auto&& comp = utility::as_function(compare);
+        auto&& proj = utility::as_function(projection);
+
+        auto middle = first + (last - first) / 2; // Ensures left partition is smaller
+        internal_mergesort(first, middle, buffer, compare, projection);
+        internal_mergesort(middle, last, buffer, compare, projection);
+
+        // Reduce left partition even more if possible
+        auto&& mid_value = proj(*middle);
+        while (first != middle && not comp(mid_value, proj(*first))) {
+            ++first;
+        }
+        if (first == middle) return;
+
+        internal_buffered_inplace_merge(first, middle, last, buffer,
+                                        std::move(compare), std::move(projection));
+    }
+
+    template<typename RandomAccessIterator, typename Compare, typename Projection>
+    auto quick_merge_sort(RandomAccessIterator first, RandomAccessIterator last,
+                          Compare compare, Projection projection)
+        -> void
+    {
+        auto size = std::distance(first, last);
+        while (size > qmsort_insertion_limit) {
+            auto pivot = first + 2 * (size / 3) - 2;
+            detail::nth_element(first, pivot, last, compare, projection);
+            internal_mergesort(first, pivot, pivot, compare, projection);
+
+            first = pivot;
+            size = std::distance(first, last);
+        }
+        insertion_sort(first, last, std::move(compare), std::move(projection));
+    }
+}}
+
+#endif // CPPSORT_DETAIL_QUICK_MERGE_SORT_H_

--- a/include/cpp-sort/fwd.h
+++ b/include/cpp-sort/fwd.h
@@ -58,6 +58,7 @@ namespace cppsort
     struct merge_sorter;
     struct pdq_sorter;
     struct poplar_sorter;
+    struct quick_merge_sorter;
     struct quick_sorter;
     struct selection_sorter;
     struct ska_sorter;

--- a/include/cpp-sort/sorters.h
+++ b/include/cpp-sort/sorters.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2017 Morwenn
+ * Copyright (c) 2015-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,7 @@
 #include <cpp-sort/sorters/merge_sorter.h>
 #include <cpp-sort/sorters/pdq_sorter.h>
 #include <cpp-sort/sorters/poplar_sorter.h>
+#include <cpp-sort/sorters/quick_merge_sorter.h>
 #include <cpp-sort/sorters/quick_sorter.h>
 #include <cpp-sort/sorters/selection_sorter.h>
 #include <cpp-sort/sorters/ska_sorter.h>

--- a/include/cpp-sort/sorters/quick_merge_sorter.h
+++ b/include/cpp-sort/sorters/quick_merge_sorter.h
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef CPPSORT_SORTERS_QUICK_MERGE_SORTER_H_
+#define CPPSORT_SORTERS_QUICK_MERGE_SORTER_H_
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <cpp-sort/sorter_facade.h>
+#include <cpp-sort/sorter_traits.h>
+#include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/static_const.h>
+#include "../detail/iterator_traits.h"
+#include "../detail/quick_merge_sort.h"
+
+namespace cppsort
+{
+    ////////////////////////////////////////////////////////////
+    // Sorter
+
+    namespace detail
+    {
+        struct quick_merge_sorter_impl
+        {
+            template<
+                typename RandomAccessIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<is_projection_iterator_v<
+                    Projection, RandomAccessIterator, Compare
+                >>
+            >
+            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> void
+            {
+                static_assert(
+                    std::is_base_of<
+                        std::random_access_iterator_tag,
+                        cppsort::detail::iterator_category_t<RandomAccessIterator>
+                    >::value,
+                    "quick_merge_sorter requires at least random-access iterators"
+                );
+
+                quick_merge_sort(std::move(first), std::move(last),
+                                 std::move(compare), std::move(projection));
+            }
+
+            ////////////////////////////////////////////////////////////
+            // Sorter traits
+
+            using iterator_category = std::random_access_iterator_tag;
+            using is_always_stable = std::false_type;
+        };
+    }
+
+    struct quick_merge_sorter:
+        sorter_facade<detail::quick_merge_sorter_impl>
+    {};
+
+    ////////////////////////////////////////////////////////////
+    // Sort function
+
+    namespace
+    {
+        constexpr auto&& quick_merge_sort
+            = utility::static_const<quick_merge_sorter>::value;
+    }
+}
+
+#endif // CPPSORT_SORTERS_QUICK_MERGE_SORTER_H_

--- a/include/cpp-sort/sorters/quick_merge_sorter.h
+++ b/include/cpp-sort/sorters/quick_merge_sorter.h
@@ -34,6 +34,7 @@
 #include <cpp-sort/sorter_facade.h>
 #include <cpp-sort/sorter_traits.h>
 #include <cpp-sort/utility/functional.h>
+#include <cpp-sort/utility/size.h>
 #include <cpp-sort/utility/static_const.h>
 #include "../detail/iterator_traits.h"
 #include "../detail/quick_merge_sort.h"
@@ -48,26 +49,52 @@ namespace cppsort
         struct quick_merge_sorter_impl
         {
             template<
-                typename RandomAccessIterator,
+                typename ForwardIterable,
                 typename Compare = std::less<>,
                 typename Projection = utility::identity,
-                typename = std::enable_if_t<is_projection_iterator_v<
-                    Projection, RandomAccessIterator, Compare
-                >>
+                typename = std::enable_if_t<
+                    is_projection_v<Projection, ForwardIterable, Compare>
+                >
             >
-            auto operator()(RandomAccessIterator first, RandomAccessIterator last,
+            auto operator()(ForwardIterable&& iterable,
                             Compare compare={}, Projection projection={}) const
                 -> void
             {
                 static_assert(
                     std::is_base_of<
-                        std::random_access_iterator_tag,
-                        cppsort::detail::iterator_category_t<RandomAccessIterator>
+                        std::forward_iterator_tag,
+                        iterator_category_t<decltype(std::begin(iterable))>
                     >::value,
-                    "quick_merge_sorter requires at least random-access iterators"
+                    "quick_merge_sorter requires at least forward iterators"
                 );
 
-                quick_merge_sort(std::move(first), std::move(last),
+                quick_merge_sort(std::begin(iterable), std::end(iterable),
+                                 utility::size(iterable),
+                                 std::move(compare), std::move(projection));
+            }
+
+            template<
+                typename ForwardIterator,
+                typename Compare = std::less<>,
+                typename Projection = utility::identity,
+                typename = std::enable_if_t<
+                    is_projection_iterator_v<Projection, ForwardIterator, Compare>
+                >
+            >
+            auto operator()(ForwardIterator first, ForwardIterator last,
+                            Compare compare={}, Projection projection={}) const
+                -> void
+            {
+                static_assert(
+                    std::is_base_of<
+                        std::forward_iterator_tag,
+                        iterator_category_t<ForwardIterator>
+                    >::value,
+                    "quick_merge_sorter requires at least forward iterators"
+                );
+
+                auto dist = std::distance(first, last);
+                quick_merge_sort(std::move(first), std::move(last), dist,
                                  std::move(compare), std::move(projection));
             }
 

--- a/testsuite/adapters/indirect_adapter_every_sorter.cpp
+++ b/testsuite/adapters/indirect_adapter_every_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Morwenn
+ * Copyright (c) 2016-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -104,6 +104,13 @@ TEST_CASE( "every sorter with indirect adapter",
     SECTION( "poplar_sorter" )
     {
         using sorter = cppsort::indirect_adapter<cppsort::poplar_sorter>;
+        cppsort::sort(sorter{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        using sorter = cppsort::indirect_adapter<cppsort::quick_merge_sorter>;
         cppsort::sort(sorter{}, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }

--- a/testsuite/adapters/schwartz_adapter_every_sorter.cpp
+++ b/testsuite/adapters/schwartz_adapter_every_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Morwenn
+ * Copyright (c) 2016-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -129,6 +129,14 @@ TEST_CASE( "every sorter with Schwartzian transform adapter",
     SECTION( "poplar_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::poplar_sorter>;
+        cppsort::sort(sorter{}, collection, &wrapper<>::value);
+        CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
+                                  std::less<>{}, &wrapper<>::value) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        using sorter = cppsort::schwartz_adapter<cppsort::quick_merge_sorter>;
         cppsort::sort(sorter{}, collection, &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
                                   std::less<>{}, &wrapper<>::value) );

--- a/testsuite/adapters/schwartz_adapter_every_sorter_reversed.cpp
+++ b/testsuite/adapters/schwartz_adapter_every_sorter_reversed.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -129,6 +129,14 @@ TEST_CASE( "every sorter with Schwartzian transform adapter and reverse iterator
     SECTION( "poplar_sorter" )
     {
         using sorter = cppsort::schwartz_adapter<cppsort::poplar_sorter>;
+        cppsort::sort(sorter{}, std::rbegin(collection), std::rend(collection), &wrapper<>::value);
+        CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
+                                  std::greater<>{}, &wrapper<>::value) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        using sorter = cppsort::schwartz_adapter<cppsort::quick_merge_sorter>;
         cppsort::sort(sorter{}, std::rbegin(collection), std::rend(collection), &wrapper<>::value);
         CHECK( helpers::is_sorted(std::begin(collection), std::end(collection),
                                   std::greater<>{}, &wrapper<>::value) );

--- a/testsuite/adapters/stable_adapter_every_sorter.cpp
+++ b/testsuite/adapters/stable_adapter_every_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Morwenn
+ * Copyright (c) 2016-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -138,6 +138,13 @@ TEST_CASE( "every sorter with stable adapter",
     SECTION( "poplar_sorter" )
     {
         using sorter = cppsort::poplar_sorter;
+        cppsort::stable_sort(sorter{}, collection, &wrapper::value);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        using sorter = cppsort::quick_merge_sorter;
         cppsort::stable_sort(sorter{}, collection, &wrapper::value);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }

--- a/testsuite/adapters/verge_adapter_every_sorter.cpp
+++ b/testsuite/adapters/verge_adapter_every_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,6 +107,13 @@ TEST_CASE( "every sorter with verge_adapter", "[verge_adapter]" )
     SECTION( "poplar_sorter" )
     {
         using sorter = cppsort::verge_adapter<cppsort::poplar_sorter>;
+        cppsort::sort(sorter{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        using sorter = cppsort::verge_adapter<cppsort::quick_merge_sorter>;
         cppsort::sort(sorter{}, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }

--- a/testsuite/distributions/all_equal.cpp
+++ b/testsuite/distributions/all_equal.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with all_equal distribution", "[distributions]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/alternating.cpp
+++ b/testsuite/distributions/alternating.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with alternating distribution", "[distributions]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/alternating_16_values.cpp
+++ b/testsuite/distributions/alternating_16_values.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with alternating_16_values distribution", "[distribution
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/ascending.cpp
+++ b/testsuite/distributions/ascending.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -102,6 +102,12 @@ TEST_CASE( "test sorter with ascending distribution", "[distributions]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/ascending_sawtooth.cpp
+++ b/testsuite/distributions/ascending_sawtooth.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with ascending_sawtooth distribution", "[distributions]"
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/descending.cpp
+++ b/testsuite/distributions/descending.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with descending distribution", "[distributions]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/descending_sawtooth.cpp
+++ b/testsuite/distributions/descending_sawtooth.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with descending_sawtooth distribution", "[distributions]
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/pipe_organ.cpp
+++ b/testsuite/distributions/pipe_organ.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with pipe_organ distribution", "[distributions]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/push_front.cpp
+++ b/testsuite/distributions/push_front.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with push_front distribution", "[distributions]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/push_middle.cpp
+++ b/testsuite/distributions/push_middle.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with push_middle distribution", "[distributions]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/shuffled.cpp
+++ b/testsuite/distributions/shuffled.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with shuffled distribution", "[distributions]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/distributions/shuffled_16_values.cpp
+++ b/testsuite/distributions/shuffled_16_values.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,12 @@ TEST_CASE( "test sorter with shuffled_16_values distribution", "[distributions]"
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sort, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sort, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/every_instantiated_sorter.cpp
+++ b/testsuite/every_instantiated_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Morwenn
+ * Copyright (c) 2016-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -99,6 +99,12 @@ TEST_CASE( "test every instantiated sorter", "[sorters]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::poplar_sort(collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::quick_merge_sort(collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/every_instantiated_sorter.cpp
+++ b/testsuite/every_instantiated_sorter.cpp
@@ -22,7 +22,9 @@
  * THE SOFTWARE.
  */
 #include <algorithm>
+#include <forward_list>
 #include <iterator>
+#include <list>
 #include <vector>
 #include <catch.hpp>
 #include <cpp-sort/sorters.h>
@@ -41,6 +43,9 @@ TEST_CASE( "test every instantiated sorter", "[sorters]" )
     std::vector<long long int> collection; collection.reserve(35);
     auto distribution = dist::shuffled{};
     distribution(std::back_inserter(collection), 35, -47);
+
+    std::list<long long int> li(std::begin(collection), std::end(collection));
+    std::forward_list<long long int> fli(std::begin(collection), std::end(collection));
 
     SECTION( "block_sort" )
     {
@@ -106,6 +111,12 @@ TEST_CASE( "test every instantiated sorter", "[sorters]" )
     {
         cppsort::quick_merge_sort(collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+
+        cppsort::quick_merge_sort(li);
+        CHECK( std::is_sorted(std::begin(li), std::end(li)) );
+
+        /*cppsort::quick_merge_sort(fli);
+        CHECK( std::is_sorted(std::begin(fli), std::end(fli)) );*/
     }
 
     SECTION( "quick_sorter" )

--- a/testsuite/every_instantiated_sorter.cpp
+++ b/testsuite/every_instantiated_sorter.cpp
@@ -115,8 +115,8 @@ TEST_CASE( "test every instantiated sorter", "[sorters]" )
         cppsort::quick_merge_sort(li);
         CHECK( std::is_sorted(std::begin(li), std::end(li)) );
 
-        /*cppsort::quick_merge_sort(fli);
-        CHECK( std::is_sorted(std::begin(fli), std::end(fli)) );*/
+        cppsort::quick_merge_sort(fli);
+        CHECK( std::is_sorted(std::begin(fli), std::end(fli)) );
     }
 
     SECTION( "quick_sorter" )

--- a/testsuite/every_sorter.cpp
+++ b/testsuite/every_sorter.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Morwenn
+ * Copyright (c) 2016-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -119,6 +119,12 @@ TEST_CASE( "test every sorter", "[sorters]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sorter{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sorter{}, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/every_sorter_internal_compare.cpp
+++ b/testsuite/every_sorter_internal_compare.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -88,6 +88,12 @@ TEST_CASE( "test every sorter with a pointer to member function comparison",
     SECTION( "poplar_sorter" )
     {
         cppsort::poplar_sort(collection, &internal_compare<int>::compare_to);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::quick_merge_sort(collection, &internal_compare<int>::compare_to);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/every_sorter_move_only.cpp
+++ b/testsuite/every_sorter_move_only.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Morwenn
+ * Copyright (c) 2016-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -103,6 +103,12 @@ TEST_CASE( "test every sorter with move-only types", "[sorters]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sorter{}, collection);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sorter{}, collection);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/every_sorter_no_post_iterator.cpp
+++ b/testsuite/every_sorter_no_post_iterator.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Morwenn
+ * Copyright (c) 2017-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -108,6 +108,12 @@ TEST_CASE( "test every sorter with no_post_iterator", "[sorters]" )
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sorter{}, first, last);
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sorter{}, first, last);
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 

--- a/testsuite/every_sorter_span.cpp
+++ b/testsuite/every_sorter_span.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Morwenn
+ * Copyright (c) 2016-2018 Morwenn
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -120,6 +120,12 @@ TEST_CASE( "test every sorter with temporary span",
     SECTION( "poplar_sorter" )
     {
         cppsort::sort(cppsort::poplar_sorter{}, make_span(collection));
+        CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
+    }
+
+    SECTION( "quick_merge_sorter" )
+    {
+        cppsort::sort(cppsort::quick_merge_sorter{}, make_span(collection));
         CHECK( std::is_sorted(std::begin(collection), std::end(collection)) );
     }
 


### PR DESCRIPTION
`quick_merge_sorter` was added to the library as a solution to sort a collection of forward iterators in O(n log n) without allocating heap memory. It required to implement median-of-medians and introselect, so those were also used to turn `quick_sorter` into some kind of introsort that falls back on an introselect pivot selection when a specific recursion threshold has been reached.