### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,8 @@ target_compile_features(cpp-sort INTERFACE cxx_std_14)
 # MSVC won't work without a stricter standard compliance
 if (MSVC)
     target_compile_options(cpp-sort INTERFACE
-        /permissive-
-        /Zc:preprocessor
+        $<$<COMPILE_LANGUAGE:CXX>:/permissive- /Zc:preprocessor>
+        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler "/permissive- /Zc:preprocessor">
     )
 endif()
 


### PR DESCRIPTION
Fixes #227 

I think these are generally desirable defaults, but I don't like imposing any flags on dependent projects. However, I haven't tested whether `/permissive-` and/or `/Zc:preprocessor` are even necessary with more recent versions of MSVC, but I guess we can still impose these MSVC options for backwards compatibility. If I find some time in the future to test this, I'll let you know and maybe we can only impose these options up to a certain `MSVC_VERSION`.