### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ if (MSVC)
     target_compile_options(cpp-sort INTERFACE
         $<$<COMPILE_LANGUAGE:CXX>:/permissive->
         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler="/permissive-">
+    )
 endif()
 
 # Handle diagnostic options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,8 @@ target_compile_features(cpp-sort INTERFACE cxx_std_14)
 # MSVC won't work without a stricter standard compliance
 if (MSVC)
     target_compile_options(cpp-sort INTERFACE
-        $<$<COMPILE_LANGUAGE:CXX>:/permissive- /Zc:preprocessor>
-        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler "/permissive- /Zc:preprocessor">
+        $<$<COMPILE_LANGUAGE:CXX>:/permissive->
+        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler="/permissive-">
     )
 endif()
 


### PR DESCRIPTION
Fixes #227 

Hi @Morwenn , I just tested this and when not using the `=` in `-Xcompiler="/permissive-"`, the `/permissive-` does not get wrapped into `-Xcompiler="..."` with all the other compile options. This is probably due to CMake's [option de-duplication](https://cmake.org/cmake/help/latest/command/target_compile_options.html#option-de-duplication). In any case, this is simple to fix and it works in my environment (`MSVC+CUDA`). Apologies for previously sending in a bad PR.

For any `cpp-sort` user reading this, I also want to add that the [`COMPILE_LANGUAGE`](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:COMPILE_LANGUAGE) generator expression applies per source file. In other words, for a given CMake project, different compilers can be used on different source files. To make sure that the `COMPILE_LANGUAGE` works correctly, either:
- Set the [`LANGUAGE`](https://cmake.org/cmake/help/latest/prop_sf/LANGUAGE.html) source file property explicitly, for example
```
get_target_property(sources mytarget SOURCES)
foreach(source IN LISTS sources)
    # Set LANGUAGE property based on extension (use different logic for your use case)
    get_filename_component(extension ${source} EXT)
    if (extension STREQUAL ".cu") # or other non-standard CUDA extension
        set_source_files_properties(${source} PROPERTIES LANGUAGE CUDA)
    elseif(extension STREQUAL ".c") # or other non-standard C extension
        set_source_files_properties(${source} PROPERTIES LANGUAGE C)
    elseif(extension STREQUAL ".cpp") # or other non-standard C++ extension
        set_source_files_properties(${source} PROPERTIES LANGUAGE CXX)
    endif()
endforeach()
```
- Use standard per-language file extensions only.